### PR TITLE
(#43) Added fix for pa11y and docker

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -1,5 +1,12 @@
 {
   "urls": [
     "http://localhost:3000"
-  ]
+  ],
+	"chromeLaunchConfig": {
+		"args": [
+			"--no-sandbox",
+			"--disable-setuid-sandbox",
+			"--disable-dev-shm-usage"
+		]
+	}
 }


### PR DESCRIPTION
This fix is needed for some circumstances where pa11y fails. However, there is only 1 URL right now.