### PR TITLE
(#46) Only c-codes should be redirected to a pretty-url

### DIFF
--- a/cypress/integration/DiseaseOnly/DiseaseCodeUglyToPrettyURL.feature
+++ b/cypress/integration/DiseaseOnly/DiseaseCodeUglyToPrettyURL.feature
@@ -5,3 +5,9 @@ Feature: As the system, I want to be able to redirect users to pretty URLs for t
 		And "pageTitle" is set to "{{disease_label}} Clinical Trials"
 		Given the user navigates to "/C4872"
 		Then the user is redirected to "/breast-cancer?redirect=true"
+
+	Scenario: Page goes to prettyURL, without appending redirect=true, when not given a c-code
+		Given "trialListingPageType" is set to "Disease"
+		And "pageTitle" is set to "{{disease_label}} Clinical Trials"
+		Given the user navigates to "/breast-cancer?cfg=0"
+		Then the redirect parameter is not appended

--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -281,6 +281,10 @@ Then('the user is redirected to {string}', (redirectUrl) => {
 		cy.location('href').should('include', redirectUrl);
 });
 
+Then('the redirect parameter is not appended', () => {
+	cy.location('href').should('not.include', 'redirect=true')
+});
+
 Then('the user is redirected to {string} with query parameters {string}', (redirectUrl, queryParams) => {
 	cy.location('href').should('include', `${redirectUrl}?${queryParams}`);
 });

--- a/src/views/CTLViewsHoC.jsx
+++ b/src/views/CTLViewsHoC.jsx
@@ -35,12 +35,10 @@ const CTLViewsHoC = (WrappedView) => {
 			paramType === 'code'
 				? getListingInformationById
 				: getListingInformationByName;
-
 		const getListingInfo = useCustomQuery(
 			getFetchByIdOrName({ queryParam }),
 			shouldFetchListingInfo && !hasBeenRedirected
 		);
-
 		useEffect(() => {
 			if (isNoTrials && !hasTrialsRedirectState) {
 				setShowPageNotFound(true);
@@ -72,7 +70,7 @@ const CTLViewsHoC = (WrappedView) => {
 				setStateListingInfo(getListingInfo.payload);
 
 				// Redirect to pretty url if one exists for listing info
-				if (prettyUrlName) {
+				if (prettyUrlName && paramType === 'code') {
 					setHasBeenRedirected(true);
 					const queryString = appendOrUpdateToQueryString(
 						search,
@@ -80,7 +78,8 @@ const CTLViewsHoC = (WrappedView) => {
 						'true'
 					);
 					navigate(
-						`${CodeOrPurlPath({ codeOrPurl: prettyUrlName })}${queryString}`
+						`${CodeOrPurlPath({ codeOrPurl: prettyUrlName })}${queryString}`,
+						{ replace: true }
 					);
 				}
 			}


### PR DESCRIPTION
Closes #46

* PrettyUrlName only appends 'redirect=true' for c-codes now
* Added integration test accordingly