### PR TITLE
(#72) Remove redirect param from prerender header

### DIFF
--- a/cypress/integration/DiseaseOnly/DiseaseCodeUglyToPrettyURL.feature
+++ b/cypress/integration/DiseaseOnly/DiseaseCodeUglyToPrettyURL.feature
@@ -6,9 +6,9 @@ Feature: As the system, I want to be able to redirect users to pretty URLs for t
 		Given the user navigates to "/C4872"
 		Then the user is redirected to "/breast-cancer?redirect=true"
 		And the page contains meta tags with the following names
-				| name                  | content 																										 |
-				| prerender-status-code | 301     																										 |
-				| prerender-header		  | Location: http://localhost:3000/breast-cancer?redirect=true  |
+				| name                  | content 																			 |
+				| prerender-status-code | 301     																			 |
+				| prerender-header		  | Location: http://localhost:3000/breast-cancer  |
 
 	Scenario: Page goes to prettyURL, without appending redirect=true, when not given a c-code
 		Given "trialListingPageType" is set to "Disease"

--- a/cypress/integration/NoTrialsFound/DiseaseRedirectToNoTrialsFound.feature
+++ b/cypress/integration/NoTrialsFound/DiseaseRedirectToNoTrialsFound.feature
@@ -13,10 +13,10 @@ Feature: As the system, I want to be able to redirect users to the No Trials Fou
 		And the CIS Banner displays below
 		And the Chat Now button displays below
 		And the page contains meta tags with the following names
-				| name                  | content 																																|
-				| prerender-status-code | 301     																																|
-				| prerender-header		  | Location: http://localhost:3000/chronic-fatigue-syndrome?redirect=true  |
-				| robots				 			  | noindex																																	|
+				| name                  | content 																									|
+				| prerender-status-code | 301     																									|
+				| prerender-header		  | Location: http://localhost:3000/chronic-fatigue-syndrome  |
+				| robots				 			  | noindex																										|
 
 
 	Scenario: Page redirects to No Trials Found page if pretty URL name is given for Disease and no trials are returned

--- a/src/views/Disease/Disease.jsx
+++ b/src/views/Disease/Disease.jsx
@@ -85,11 +85,13 @@ const Disease = ({ data: [data] }) => {
 		if (!queryResponse.loading && queryResponse.payload) {
 			if (queryResponse.payload.total === 0) {
 				const noTrialsParam = prettyUrlName ? prettyUrlName : codeOrPurl;
+
 				const redirectStatusCode = location.state?.redirectStatus
 					? location.state?.redirectStatus
 					: '302';
+
 				const prerenderLocation = location.state?.redirectStatus
-					? baseHost + window.location.pathname + window.location.search
+					? baseHost + window.location.pathname
 					: null;
 
 				// So this is handling the redirect to the no trials page.
@@ -136,8 +138,7 @@ const Disease = ({ data: [data] }) => {
 	};
 
 	const renderHelmet = () => {
-		const prerenderHeader =
-			baseHost + window.location.pathname + window.location.search;
+		const prerenderHeader = baseHost + window.location.pathname;
 		const status = location.state?.redirectStatus;
 
 		return (


### PR DESCRIPTION
Closes #72

* Remove redirect query params from prerender header value in Disease
* Update integration tests