### PR TITLE
(#100) Fix useListingSupport

### DIFF
--- a/src/hooks/listingSupport/__tests__/useListingSupport.test.js
+++ b/src/hooks/listingSupport/__tests__/useListingSupport.test.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { act, render, screen } from '@testing-library/react';
 import { useListingSupport } from '../useListingSupport';
 import { getListingInformationById as IdAction } from '../../../services/api/actions/getListingInformationById';
 import { getListingInformationByName as NameAction } from '../../../services/api/actions/getListingInformationByName';
+import { getTrialType as TrialTypeAction } from '../../../services/api/actions/getTrialType';
 import { getListingInformationById } from '../../../services/api/trial-listing-support-api/getListingInformationById';
 import { getListingInformationByName } from '../../../services/api/trial-listing-support-api/getListingInformationByName';
+import { getTrialType } from '../../../services/api/trial-listing-support-api/getTrialType';
 import { useStateValue } from '../../../store/store';
 
 jest.mock('../../../store/store');
@@ -16,23 +17,43 @@ jest.mock(
 	'../../../services/api/trial-listing-support-api/getListingInformationByName'
 );
 
-const UseListingSupportSample = ({ actions }) => {
+jest.mock('../../../services/api/trial-listing-support-api/getTrialType');
+
+/* eslint-disable react/prop-types */
+const UseListingSupportSample = ({ actions, testId }) => {
 	const { loading, payload, error, aborted } = useListingSupport(actions);
 
 	return (
 		<div>
 			{(() => {
 				if (!loading && payload) {
-					// Smush all the codes together into a string so we can test...
-					// TODO: when we write the multiple item tests we need to account
-					// for the calls being concept or trials type.
-					const ids = payload.reduce((ac, curr) => {
-						return (
-							(ac === '' ? ac : ac + '|') +
-							(curr !== null ? curr.conceptId.join(',') : 'null')
-						);
-					}, '');
-					return <h1>Payload: {ids}</h1>;
+					return (
+						<>
+							<h1>Payloads</h1>
+							<ul>
+								{payload.map((res, idx) => {
+									if (res === null) {
+										return <li key={idx}>Payload[{idx}]: null </li>;
+									} else if (res.conceptId) {
+										return (
+											<li key={idx}>
+												Payload[{idx}]-ids: {res.conceptId.join(',')}
+											</li>
+										);
+									} else if (res.idString) {
+										return (
+											<li key={idx}>
+												Payload[{idx}]-ids: {res.idString}
+											</li>
+										);
+									} else {
+										return <li key={idx}>Payload[{idx}]: unknown</li>;
+									}
+								})}
+							</ul>
+							<h2>TestId: {testId} </h2>
+						</>
+					);
 				} else if (!loading && error) {
 					return <h1>Error: {error.message}</h1>;
 				} else if (!loading && aborted) {
@@ -44,146 +65,566 @@ const UseListingSupportSample = ({ actions }) => {
 		</div>
 	);
 };
-// Shutup the linter...
-UseListingSupportSample.propTypes = {
-	actions: PropTypes.array,
-};
 
 describe('useListingSupport', () => {
-	it('should fetch the data with one ID', async () => {
-		// This will work for now because we don't care it is
-		// an axios instance. When we add in aborting, we will
-		// very much care.
-		useStateValue.mockReturnValue([
-			{
-				appId: 'mockAppId',
-				apiClients: { trialListingSupportClient: true },
-			},
-		]);
-
-		getListingInformationById.mockReturnValue({
-			conceptId: ['C4872'],
-			name: {
-				label: 'Breast Cancer',
-				normalized: 'breast cancer',
-			},
-			prettyUrlName: 'breast-cancer',
-		});
-		const actions = [IdAction({ id: ['C4872'] })];
-
-		await act(async () => {
-			render(<UseListingSupportSample actions={actions} />);
-		});
-
-		// TODO: Make this actually check the payload
-		expect(screen.getByText('Payload: C4872')).toBeInTheDocument();
+	beforeEach(() => {
+		jest.clearAllMocks();
 	});
 
-	it('should fetch the data with one Name', async () => {
-		// This will work for now because we don't care it is
-		// an axios instance. When we add in aborting, we will
-		// very much care.
-		useStateValue.mockReturnValue([
-			{
-				appId: 'mockAppId',
-				apiClients: { trialListingSupportClient: true },
-			},
-		]);
+	describe('one paramater use cases', () => {
+		it('should fetch the data with one ID', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
 
-		getListingInformationByName.mockReturnValue({
-			conceptId: ['C4872'],
-			name: {
-				label: 'Breast Cancer',
-				normalized: 'breast cancer',
-			},
-			prettyUrlName: 'breast-cancer',
+			getListingInformationById.mockReturnValue({
+				conceptId: ['C4872'],
+				name: {
+					label: 'Breast Cancer',
+					normalized: 'breast cancer',
+				},
+				prettyUrlName: 'breast-cancer',
+			});
+			const actions = [IdAction({ ids: ['C4872'] })];
+
+			await act(async () => {
+				render(<UseListingSupportSample actions={actions} />);
+			});
+
+			expect(screen.getByText('Payload[0]-ids: C4872')).toBeInTheDocument();
+			expect(getListingInformationById.mock.calls).toHaveLength(1);
+			expect(getListingInformationById.mock.calls[0][1]).toEqual(['C4872']);
 		});
-		const actions = [NameAction({ name: 'breast-cancer' })];
 
-		await act(async () => {
-			render(<UseListingSupportSample actions={actions} />);
+		it('should fetch the data with one Name', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
+
+			getListingInformationByName.mockReturnValue({
+				conceptId: ['C4872'],
+				name: {
+					label: 'Breast Cancer',
+					normalized: 'breast cancer',
+				},
+				prettyUrlName: 'breast-cancer',
+			});
+			const actions = [NameAction({ name: 'breast-cancer' })];
+
+			await act(async () => {
+				render(<UseListingSupportSample actions={actions} />);
+			});
+
+			expect(screen.getByText('Payload[0]-ids: C4872')).toBeInTheDocument();
+			expect(getListingInformationByName.mock.calls).toHaveLength(1);
 		});
 
-		// TODO: Make this actually check the payload.
-		expect(screen.getByText('Payload: C4872')).toBeInTheDocument();
+		it('should fetch the data for a trial type', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
+
+			getTrialType.mockReturnValue({
+				prettyUrlName: 'treatment',
+				idString: 'treatment',
+				label: 'Treatment',
+			});
+
+			const actions = [TrialTypeAction({ trialType: 'treatment' })];
+
+			await act(async () => {
+				render(<UseListingSupportSample actions={actions} />);
+			});
+
+			expect(screen.getByText('Payload[0]-ids: treatment')).toBeInTheDocument();
+			expect(getTrialType.mock.calls).toHaveLength(1);
+		});
 	});
 
-	it('should handle a 404', async () => {
-		// This will work for now because we don't care it is
-		// an axios instance. When we add in aborting, we will
-		// very much care.
-		useStateValue.mockReturnValue([
-			{
-				appId: 'mockAppId',
-				apiClients: { trialListingSupportClient: true },
-			},
-		]);
+	describe('multi-parameter use cases', () => {
+		it('handles multiple parameters', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
 
-		getListingInformationById.mockImplementation(() => {
-			return null;
+			getListingInformationById.mockReturnValue({
+				conceptId: ['C4872'],
+				name: {
+					label: 'Breast Cancer',
+					normalized: 'breast cancer',
+				},
+				prettyUrlName: 'breast-cancer',
+			});
+
+			getTrialType.mockReturnValue({
+				prettyUrlName: 'treatment',
+				idString: 'treatment',
+				label: 'Treatment',
+			});
+
+			const actions = [
+				IdAction({ ids: ['C4872'] }),
+				TrialTypeAction({ trialType: 'treatment' }),
+			];
+
+			await act(async () => {
+				render(<UseListingSupportSample actions={actions} />);
+			});
+
+			expect(screen.getByText('Payload[0]-ids: C4872')).toBeInTheDocument();
+			expect(screen.getByText('Payload[1]-ids: treatment')).toBeInTheDocument();
+			expect(getListingInformationById.mock.calls).toHaveLength(1);
+			expect(getListingInformationById.mock.calls[0][1]).toEqual(['C4872']);
+			expect(getTrialType.mock.calls).toHaveLength(1);
+			expect(getTrialType.mock.calls[0][1]).toEqual('treatment');
 		});
-		const actions = [IdAction({ id: ['C4872'] })];
-
-		await act(async () => {
-			render(<UseListingSupportSample actions={actions} />);
-		});
-
-		// TODO: Make this actually check the payload
-		expect(screen.getByText('Payload: null')).toBeInTheDocument();
 	});
 
-	it('should handle a error with unknown type', async () => {
-		// This will work for now because we don't care it is
-		// an axios instance. When we add in aborting, we will
-		// very much care.
-		useStateValue.mockReturnValue([
-			{
-				appId: 'mockAppId',
-				apiClients: { trialListingSupportClient: true },
-			},
-		]);
+	describe('route changing use cases', () => {
+		it('handles changing concepts from one to another', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
 
-		getListingInformationById.mockImplementation(() => {
-			throw new Error('Bad Mojo');
+			getListingInformationById
+				.mockReturnValueOnce({
+					conceptId: ['C4872'],
+					name: {
+						label: 'Breast Cancer',
+						normalized: 'breast cancer',
+					},
+					prettyUrlName: 'breast-cancer',
+				})
+				.mockReturnValueOnce({
+					conceptId: ['C99999'],
+					name: {
+						label: 'Dummy Concept',
+						normalized: 'dummy concept',
+					},
+					prettyUrlName: 'dummy-concept',
+				});
+
+			let renderRtn;
+			// Pass 1.
+			const actions = [IdAction({ ids: ['C4872'] })];
+			await act(async () => {
+				renderRtn = render(
+					<UseListingSupportSample actions={actions} testId={'round1'} />
+				);
+			});
+			expect(screen.getByText('TestId: round1')).toBeInTheDocument();
+			expect(screen.getByText('Payload[0]-ids: C4872')).toBeInTheDocument();
+
+			const actionsPt2 = [IdAction({ ids: ['C99999'] })];
+			await act(async () => {
+				renderRtn.rerender(
+					<UseListingSupportSample actions={actionsPt2} testId={'round2'} />
+				);
+			});
+			expect(screen.getByText('Payload[0]-ids: C99999')).toBeInTheDocument();
+			expect(screen.getByText('TestId: round2')).toBeInTheDocument();
+			expect(screen.queryByText('TestId: round1')).toBeNull();
+			expect(getListingInformationById.mock.calls).toHaveLength(2);
+			expect(getListingInformationById.mock.calls[0][1]).toEqual(['C4872']);
+			expect(getListingInformationById.mock.calls[1][1]).toEqual(['C99999']);
 		});
-		const actions = [
-			{
-				type: 'dummy',
-				payload: { a: 1 },
-			},
-		];
 
-		await act(async () => {
-			render(<UseListingSupportSample actions={actions} />);
+		it('handles same concept but changing ids from one to another', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
+
+			getListingInformationById
+				.mockReturnValueOnce({
+					conceptId: ['C1111', 'C2222'],
+					name: {
+						label: 'Multi-id concept',
+						normalized: 'multi-id concept',
+					},
+					prettyUrlName: 'multi-id-concept',
+				})
+				.mockReturnValueOnce({
+					conceptId: ['C1111', 'C2222'],
+					name: {
+						label: 'Multi-id concept',
+						normalized: 'multi-id concept',
+					},
+					prettyUrlName: 'multi-id-concept',
+				});
+
+			let renderRtn;
+			// Pass 1.
+			const actions = [IdAction({ ids: ['C1111'] })];
+			await act(async () => {
+				renderRtn = render(
+					<UseListingSupportSample actions={actions} testId={'round1'} />
+				);
+			});
+			expect(screen.getByText('TestId: round1')).toBeInTheDocument();
+			expect(
+				screen.getByText('Payload[0]-ids: C1111,C2222')
+			).toBeInTheDocument();
+
+			const actionsPt2 = [IdAction({ ids: ['C2222'] })];
+			await act(async () => {
+				renderRtn.rerender(
+					<UseListingSupportSample actions={actionsPt2} testId={'round2'} />
+				);
+			});
+			expect(
+				screen.getByText('Payload[0]-ids: C1111,C2222')
+			).toBeInTheDocument();
+			expect(screen.getByText('TestId: round2')).toBeInTheDocument();
+			expect(screen.queryByText('TestId: round1')).toBeNull();
+			expect(getListingInformationById.mock.calls).toHaveLength(2);
+			expect(getListingInformationById.mock.calls[0][1]).toEqual(['C1111']);
+			expect(getListingInformationById.mock.calls[1][1]).toEqual(['C2222']);
 		});
 
-		// TODO: Make this actually check the payload
-		expect(
-			screen.getByText('Error: Unknown trial listing support request')
-		).toBeInTheDocument();
+		it('handles id to name transition', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
+
+			getListingInformationById.mockReturnValueOnce({
+				conceptId: ['C4872'],
+				name: {
+					label: 'Breast Cancer',
+					normalized: 'breast cancer',
+				},
+				prettyUrlName: 'breast-cancer',
+			});
+
+			getListingInformationByName.mockReturnValueOnce({
+				conceptId: ['C4872'],
+				name: {
+					label: 'Breast Cancer',
+					normalized: 'breast cancer',
+				},
+				prettyUrlName: 'breast-cancer',
+			});
+
+			let renderRtn;
+			// Pass 1.
+			const actions = [IdAction({ ids: ['C4872'] })];
+			await act(async () => {
+				renderRtn = render(
+					<UseListingSupportSample actions={actions} testId={'round1'} />
+				);
+			});
+			expect(screen.getByText('TestId: round1')).toBeInTheDocument();
+			expect(screen.getByText('Payload[0]-ids: C4872')).toBeInTheDocument();
+
+			const actionsPt2 = [NameAction({ name: 'breast-cancer' })];
+			await act(async () => {
+				renderRtn.rerender(
+					<UseListingSupportSample actions={actionsPt2} testId={'round2'} />
+				);
+			});
+			expect(screen.getByText('Payload[0]-ids: C4872')).toBeInTheDocument();
+			expect(screen.getByText('TestId: round2')).toBeInTheDocument();
+			expect(screen.queryByText('TestId: round1')).toBeNull();
+			expect(getListingInformationById.mock.calls).toHaveLength(1);
+			expect(getListingInformationById.mock.calls[0][1]).toEqual(['C4872']);
+			// TODO: Once caching is added the below mocks should NOT get called.
+			expect(getListingInformationByName.mock.calls).toHaveLength(1);
+			expect(getListingInformationByName.mock.calls[0][1]).toEqual(
+				'breast-cancer'
+			);
+		});
+
+		it('handles adding then removing parameters', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
+
+			getListingInformationById.mockImplementation((client, ids) => {
+				if (ids.includes('C1111') || ids.includes('C2222')) {
+					return {
+						conceptId: ['C1111', 'C2222'],
+						name: {
+							label: 'Multi-id concept',
+							normalized: 'multi-id concept',
+						},
+						prettyUrlName: 'multi-id-concept',
+					};
+				} else if (ids.includes('C99999')) {
+					return {
+						conceptId: ['C99999'],
+						name: {
+							label: 'Dummy Concept',
+							normalized: 'dummy concept',
+						},
+						prettyUrlName: 'dummy-concept',
+					};
+				}
+			});
+
+			getListingInformationByName.mockImplementation((client, name) => {
+				if (name === 'multi-id-concept') {
+					return {
+						conceptId: ['C1111', 'C2222'],
+						name: {
+							label: 'Multi-id concept',
+							normalized: 'multi-id concept',
+						},
+						prettyUrlName: 'multi-id-concept',
+					};
+				} else if (name === 'dummy-concept') {
+					return {
+						conceptId: ['C99999'],
+						name: {
+							label: 'Dummy Concept',
+							normalized: 'dummy concept',
+						},
+						prettyUrlName: 'dummy-concept',
+					};
+				}
+			});
+
+			getTrialType.mockImplementation((client, trialType) => {
+				if (trialType === 'treatment') {
+					return {
+						prettyUrlName: 'treatment',
+						idString: 'treatment',
+						label: 'Treatment',
+					};
+				}
+			});
+
+			let renderRtn;
+
+			// Round 1
+			const actions = [IdAction({ ids: ['C1111', 'C2222'] })];
+
+			await act(async () => {
+				renderRtn = render(
+					<UseListingSupportSample actions={actions} testId={'round1'} />
+				);
+			});
+
+			expect(
+				screen.getByText('Payload[0]-ids: C1111,C2222')
+			).toBeInTheDocument();
+			expect(screen.getByText('TestId: round1')).toBeInTheDocument();
+			expect(getListingInformationById.mock.calls).toHaveLength(1);
+			expect(getListingInformationById.mock.calls[0][1]).toEqual([
+				'C1111',
+				'C2222',
+			]);
+
+			// Round 2
+			const actions2 = [
+				NameAction({ name: 'multi-id-concept' }),
+				TrialTypeAction({ trialType: 'treatment' }),
+			];
+
+			await act(async () => {
+				renderRtn.rerender(
+					<UseListingSupportSample actions={actions2} testId={'round2'} />
+				);
+			});
+			expect(
+				screen.getByText('Payload[0]-ids: C1111,C2222')
+			).toBeInTheDocument();
+			expect(screen.getByText('Payload[1]-ids: treatment')).toBeInTheDocument();
+			expect(screen.getByText('TestId: round2')).toBeInTheDocument();
+			// No change to get by ID
+			expect(getListingInformationById.mock.calls).toHaveLength(1);
+
+			// Name should be added.
+			expect(getListingInformationByName.mock.calls).toHaveLength(1);
+			expect(getListingInformationByName.mock.calls[0][1]).toEqual(
+				'multi-id-concept'
+			);
+
+			// Name should be added.
+			expect(getTrialType.mock.calls).toHaveLength(1);
+			expect(getTrialType.mock.calls[0][1]).toEqual('treatment');
+
+			// Round 3
+			const actions3 = [
+				IdAction({ ids: ['C2222'] }),
+				TrialTypeAction({ trialType: 'treatment' }),
+				NameAction({ name: 'dummy-concept' }),
+			];
+
+			await act(async () => {
+				renderRtn.rerender(
+					<UseListingSupportSample actions={actions3} testId={'round3'} />
+				);
+			});
+			expect(
+				screen.getByText('Payload[0]-ids: C1111,C2222')
+			).toBeInTheDocument();
+			expect(screen.getByText('Payload[1]-ids: treatment')).toBeInTheDocument();
+			expect(screen.getByText('Payload[2]-ids: C99999')).toBeInTheDocument();
+
+			expect(screen.getByText('TestId: round3')).toBeInTheDocument();
+
+			// Added a call to get by Id.
+			// TODO: With caching this should be back to 1 as we are asking
+			// for the same concept
+			expect(getListingInformationById.mock.calls).toHaveLength(2);
+			expect(getListingInformationById.mock.calls[1][1]).toEqual(['C2222']);
+
+			// Another name fetch should have happened.
+			expect(getListingInformationByName.mock.calls).toHaveLength(2);
+			expect(getListingInformationByName.mock.calls[1][1]).toEqual(
+				'dummy-concept'
+			);
+
+			// Another name call should have happened.
+			expect(getTrialType.mock.calls).toHaveLength(2);
+			expect(getTrialType.mock.calls[1][1]).toEqual('treatment');
+
+			// Round 4
+			const actions4 = [IdAction({ ids: ['C99999'] })];
+
+			await act(async () => {
+				renderRtn.rerender(
+					<UseListingSupportSample actions={actions4} testId={'round4'} />
+				);
+			});
+			expect(screen.getByText('Payload[0]-ids: C99999')).toBeInTheDocument();
+			expect(screen.getByText('TestId: round4')).toBeInTheDocument();
+
+			// Added a call to get by Id.
+			// TODO: With caching this should be back to 1 as we are asking
+			// for the same concept
+			expect(getListingInformationById.mock.calls).toHaveLength(3);
+			expect(getListingInformationById.mock.calls[2][1]).toEqual(['C99999']);
+
+			// No more name fetches
+			expect(getListingInformationByName.mock.calls).toHaveLength(2);
+
+			// No more trial type fetches.
+			expect(getTrialType.mock.calls).toHaveLength(2);
+		});
 	});
 
-	it('should handle a generic error from a fetch', async () => {
-		// This will work for now because we don't care it is
-		// an axios instance. When we add in aborting, we will
-		// very much care.
-		useStateValue.mockReturnValue([
-			{
-				appId: 'mockAppId',
-				apiClients: { trialListingSupportClient: true },
-			},
-		]);
+	describe('error cases', () => {
+		it('should handle a 404', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
 
-		getListingInformationById.mockImplementation(() => {
-			throw new Error('Bad Mojo');
+			getListingInformationById.mockImplementation(() => {
+				return null;
+			});
+			const actions = [IdAction({ ids: ['C4872'] })];
+
+			await act(async () => {
+				render(<UseListingSupportSample actions={actions} />);
+			});
+
+			// TODO: Make this actually check the payload
+			expect(screen.getByText('Payload[0]: null')).toBeInTheDocument();
 		});
-		const actions = [IdAction({ id: ['C4872'] })];
 
-		await act(async () => {
-			render(<UseListingSupportSample actions={actions} />);
+		it('should handle a error with unknown type', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
+
+			const actions = [
+				{
+					type: 'dummy',
+					payload: { a: 1 },
+				},
+			];
+
+			await act(async () => {
+				render(<UseListingSupportSample actions={actions} />);
+			});
+
+			expect(
+				screen.getByText('Error: Unknown trial listing support request')
+			).toBeInTheDocument();
 		});
 
-		// TODO: Make this actually check the payload
-		expect(screen.getByText('Error: Bad Mojo')).toBeInTheDocument();
+		it('should handle a generic error from a fetch', async () => {
+			// This will work for now because we don't care it is
+			// an axios instance. When we add in aborting, we will
+			// very much care.
+			useStateValue.mockReturnValue([
+				{
+					appId: 'mockAppId',
+					apiClients: { trialListingSupportClient: true },
+				},
+			]);
+
+			getListingInformationById.mockImplementation(() => {
+				throw new Error('Bad Mojo');
+			});
+			const actions = [IdAction({ ids: ['C4872'] })];
+
+			await act(async () => {
+				render(<UseListingSupportSample actions={actions} />);
+			});
+
+			expect(screen.getByText('Error: Bad Mojo')).toBeInTheDocument();
+			expect(getListingInformationById.mock.calls).toHaveLength(1);
+		});
 	});
 });

--- a/src/hooks/listingSupport/useListingSupport.js
+++ b/src/hooks/listingSupport/useListingSupport.js
@@ -12,6 +12,7 @@ import {
 	getListingInformationByName,
 	getTrialType,
 } from '../../services/api/trial-listing-support-api';
+import { convertObjectToBase64 } from '../../utils/objects';
 import { useStateValue } from '../../store/store';
 
 /**
@@ -101,6 +102,8 @@ export const useListingSupport = (actions) => {
 		aborted: false,
 	});
 
+	const actionsHash = convertObjectToBase64(actions);
+
 	// We onlu want to fire this the first time useListingSupport
 	// is called.
 	useEffect(() => {
@@ -115,7 +118,7 @@ export const useListingSupport = (actions) => {
 			isMounted.current = false;
 			handleAbort();
 		};
-	}, []);
+	}, [actionsHash]);
 
 	// This call back handles the fetch to the api. We use is call back
 	// so the query does not execute except when any of the actions have

--- a/src/services/api/actions/__tests__/getListingInformationById.test.js
+++ b/src/services/api/actions/__tests__/getListingInformationById.test.js
@@ -1,7 +1,7 @@
 import { getListingInformationById } from '../getListingInformationById';
 
 describe('getListingInformationById action', () => {
-	test('should match getListingInformationById action', () => {
+	it('should match getListingInformationById action', () => {
 		const ids = ['C5816', 'C8550', 'C3813'];
 
 		const expectedAction = {
@@ -10,5 +10,17 @@ describe('getListingInformationById action', () => {
 		};
 
 		expect(getListingInformationById({ ids })).toEqual(expectedAction);
+	});
+
+	it('handles exception when passed incorrect data because we do not use typescript and do not have type safety', () => {
+		expect(() => {
+			getListingInformationById({ id: [2] });
+		}).toThrowError('You must specify ids in order to fetch them.');
+		expect(() => {
+			getListingInformationById({ ids: 'chicken' });
+		}).toThrowError('You must specify ids in order to fetch them.');
+		expect(() => {
+			getListingInformationById({ ids: null });
+		}).toThrowError('You must specify ids in order to fetch them.');
 	});
 });

--- a/src/services/api/actions/__tests__/getListingInformationByName.test.js
+++ b/src/services/api/actions/__tests__/getListingInformationByName.test.js
@@ -1,7 +1,7 @@
 import { getListingInformationByName } from '../getListingInformationByName';
 
 describe('getListingInformationByName action', () => {
-	test('should match getListingInformationByName action', () => {
+	it('should match getListingInformationByName action', () => {
 		const name = 'breast-cancer';
 
 		const expectedAction = {
@@ -10,5 +10,14 @@ describe('getListingInformationByName action', () => {
 		};
 
 		expect(getListingInformationByName({ name })).toEqual(expectedAction);
+	});
+
+	it('handles exception when passed incorrect data because we do not use typescript and do not have type safety', () => {
+		expect(() => {
+			getListingInformationByName({ foo: [20] });
+		}).toThrowError('You must specify a name in order to fetch it.');
+		expect(() => {
+			getListingInformationByName({ name: null });
+		}).toThrowError('You must specify a name in order to fetch it.');
 	});
 });

--- a/src/services/api/actions/__tests__/getTrialType.test.js
+++ b/src/services/api/actions/__tests__/getTrialType.test.js
@@ -1,0 +1,23 @@
+import { getTrialType } from '../getTrialType';
+
+describe('getTrialType action', () => {
+	it('should match getTrialType action', () => {
+		const trialType = 'treatment';
+
+		const expectedAction = {
+			type: 'trialType',
+			payload: 'treatment',
+		};
+
+		expect(getTrialType({ trialType })).toEqual(expectedAction);
+	});
+
+	it('handles exception when passed incorrect data because we do not use typescript and do not have type safety', () => {
+		expect(() => {
+			getTrialType({ foo: [20] });
+		}).toThrowError('You must specify a trialType in order to fetch it.');
+		expect(() => {
+			getTrialType({ trialType: null });
+		}).toThrowError('You must specify a trialType in order to fetch it.');
+	});
+});

--- a/src/services/api/actions/getListingInformationById.js
+++ b/src/services/api/actions/getListingInformationById.js
@@ -4,6 +4,10 @@
  * @param {Array<string>} ids the concept ID(s) to match
  */
 export const getListingInformationById = ({ ids = [] }) => {
+	if (!ids || !Array.isArray(ids) || ids.length === 0) {
+		throw new Error('You must specify ids in order to fetch them.');
+	}
+
 	return {
 		type: 'id',
 		payload: ids,

--- a/src/services/api/actions/getListingInformationByName.js
+++ b/src/services/api/actions/getListingInformationByName.js
@@ -4,6 +4,10 @@
  * @param {string} queryParam the pretty URL name to match
  */
 export const getListingInformationByName = ({ name = '' }) => {
+	if (!name || name === '') {
+		throw new Error('You must specify a name in order to fetch it.');
+	}
+
 	return {
 		type: 'name',
 		payload: name,

--- a/src/services/api/actions/getTrialType.js
+++ b/src/services/api/actions/getTrialType.js
@@ -4,6 +4,10 @@
  * @param {string} trialType the trial type to match
  */
 export const getTrialType = ({ trialType = '' }) => {
+	if (!trialType || trialType === '') {
+		throw new Error('You must specify a trialType in order to fetch it.');
+	}
+
 	return {
 		payload: trialType,
 		type: 'trialType',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,7 +8,7 @@ export { getStateNameFromAbbr } from './getStateNameFromAbbr';
 export { formatNumberToThousands } from './number';
 export { matchItemToTerm } from './matchItemToTerm';
 export { matchQueryParam } from './matchQueryParam';
-export { getKeyValueFromObject } from './objects';
+export { getKeyValueFromObject, convertObjectToBase64 } from './objects';
 export { TokenParser } from './replaceTokens';
 export { emboldenSubstring } from './strings';
 export { appendOrUpdateToQueryString, getKeyValueFromQueryString } from './url';

--- a/src/utils/objects.js
+++ b/src/utils/objects.js
@@ -7,3 +7,12 @@ export const getKeyValueFromObject = (key, obj) => {
 	});
 	return retValue;
 };
+
+/**
+ * Gets a hash for an object.
+ *
+ * @param {object} obj the object to hash
+ */
+export const convertObjectToBase64 = (obj) => {
+	return Buffer.from(JSON.stringify(obj)).toString('base64');
+};

--- a/src/views/__tests__/CTLViewsHoc.useListingHocInt.js
+++ b/src/views/__tests__/CTLViewsHoc.useListingHocInt.js
@@ -1,0 +1,438 @@
+/* This is not exactly an unit test, it is more of an integration test.
+ * However, this is really testing of CTLViewHoc + useListingSupport, but
+ * with fake components. These two items really go hand in hand with each
+ * other. We found that when multiple calls are made the previous logic
+ * was messing up between 2 calls as the tests were only checking initial
+ * calls.
+ *
+ * So for all these test we do not want to mock useListingSupport, but
+ * we want to mock the API calls it makes. We then want to ensure that
+ * the mockComponent is correctly called.
+ */
+import React, { useEffect } from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
+
+import { MockAnalyticsProvider } from '../../tracking';
+
+import { useStateValue } from '../../store/store';
+import { getListingInformationById } from '../../services/api/trial-listing-support-api/getListingInformationById';
+import { getListingInformationByName } from '../../services/api/trial-listing-support-api/getListingInformationByName';
+import { getTrialType } from '../../services/api/trial-listing-support-api/getTrialType';
+
+import CTLViewsHoC from '../CTLViewsHoC';
+import { act } from 'react-dom/test-utils';
+
+jest.mock('../../store/store');
+jest.mock(
+	'../../services/api/trial-listing-support-api/getListingInformationById'
+);
+jest.mock(
+	'../../services/api/trial-listing-support-api/getListingInformationByName'
+);
+
+jest.mock('../../services/api/trial-listing-support-api/getTrialType');
+
+describe('CTLViewsHoc & useListingSupport integration', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	// This will work for now because we don't care it is
+	// an axios instance. When we add in aborting, we will
+	// very much care.
+	useStateValue.mockReturnValue([
+		{
+			appId: 'mockAppId',
+			apiClients: { trialListingSupportClient: true },
+			basePath: '/',
+		},
+	]);
+
+	// Currently, while there are no tests for it,
+	// a full param map will be filtered down to
+	// only those parameters that exist in memory.
+	// So we should be able to handle this for all of
+	// our tests.
+	const diseaseRouteParamMap = [
+		{
+			paramName: 'codeOrPurl',
+			textReplacementKey: 'disease',
+			type: 'listing-information',
+		},
+		{
+			paramName: 'type',
+			textReplacementKey: 'trial_type',
+			type: 'trial-type',
+		},
+		{
+			paramName: 'interCodeOrPurl',
+			textReplacementKey: 'intervention',
+			type: 'listing-information',
+		},
+	];
+
+	// Let's set up some API responses that we are going to reuse all over
+	// the place, which is end up being hard to read.
+	const CONCEPT_BREAST_CANCER = {
+		conceptId: ['C4872'],
+		name: {
+			label: 'Breast Cancer',
+			normalized: 'breast cancer',
+		},
+		prettyUrlName: 'breast-cancer',
+	};
+
+	const CONCEPT_MULTI_ID = {
+		conceptId: ['C1111', 'C2222'],
+		name: {
+			label: 'Multi-id Concept',
+			normalized: 'multi-id concept',
+		},
+		prettyUrlName: 'multi-id-concept',
+	};
+
+	const CONCEPT_NO_PURL = {
+		conceptId: ['C99999'],
+		name: {
+			label: 'No Purl Concept',
+			normalized: 'no purl concept',
+		},
+		prettyUrlName: null,
+	};
+
+	const TRIAL_TYPE_TREATMENT = {
+		prettyUrlName: 'treatment',
+		idString: 'treatment',
+		label: 'Treatment',
+	};
+
+	/**
+	 * Let's handle our default goto for redirecting from the ugly URL
+	 * to the pretty URL based on name for a single param.
+	 */
+	it('handles navigation from ID to Name', async () => {
+		getListingInformationById.mockReturnValue(CONCEPT_BREAST_CANCER);
+		getListingInformationByName.mockReturnValue(CONCEPT_BREAST_CANCER);
+
+		// We use RedirectPath to figure out the correct route for
+		// a redirect. This assumes /:codeOrPurl which matches our
+		// route below.
+		const mockRedirectPath = jest.fn().mockReturnValue('/breast-cancer');
+
+		const mockComponent = jest.fn(() => {
+			return <>This would be the disease component.</>;
+		});
+
+		const WrappedComponent = CTLViewsHoC(mockComponent);
+
+		// Hopefully this renders, and navigates and loads the
+		// new component.
+		await act(async () => {
+			render(
+				<MockAnalyticsProvider>
+					<MemoryRouter initialEntries={['/C4872']}>
+						<Routes>
+							<Route
+								path="/:codeOrPurl"
+								element={
+									<WrappedComponent
+										redirectPath={mockRedirectPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+							/>
+						</Routes>
+					</MemoryRouter>
+				</MockAnalyticsProvider>
+			);
+		});
+
+		// Initial Call
+		expect(getListingInformationById.mock.calls).toHaveLength(1);
+		expect(getListingInformationById.mock.calls[0][1]).toEqual(['C4872']);
+
+		// Redirect call
+		// TODO: When caching is implemented this should be expected to
+		// be 0 calls as it will have been cached.
+		expect(getListingInformationByName.mock.calls).toHaveLength(1);
+		expect(getListingInformationByName.mock.calls[0][1]).toEqual(
+			'breast-cancer'
+		);
+
+		// There should only be 1 call to our component as the HoC would have:
+		// Fetched the ID, then redirected, then fetched the second, then it
+		// would render our wrapped component.
+		expect(mockComponent.mock.calls).toHaveLength(1);
+		const { data: call1data } = mockComponent.mock.calls[0][0];
+
+		expect(call1data).toEqual([CONCEPT_BREAST_CANCER]);
+	});
+
+	/**
+	 * Let's handle our redirect when we only have 1 URL to handle
+	 */
+	it('handles navigation from ID to Name with only 1 pretty url', async () => {
+		getListingInformationById.mockImplementation((client, ids) => {
+			if (ids.includes('C1111') || ids.includes('C2222')) {
+				return CONCEPT_MULTI_ID;
+			} else if (ids.includes('C99999')) {
+				return CONCEPT_NO_PURL;
+			}
+		});
+
+		getListingInformationByName.mockImplementation((client, name) => {
+			if (name === 'multi-id-concept') {
+				return CONCEPT_MULTI_ID;
+			}
+		});
+
+		getTrialType.mockImplementation((client, trialType) => {
+			if (trialType === 'treatment') {
+				return TRIAL_TYPE_TREATMENT;
+			}
+		});
+
+		// We use RedirectPath to figure out the correct route for
+		// a redirect. This assumes /:codeOrPurl which matches our
+		// route below.
+		const mockRedirectPath = jest
+			.fn()
+			.mockReturnValue('/C99999/treatment/multi-id-concept');
+
+		const mockComponent = jest.fn(() => {
+			return <>This would be the disease component.</>;
+		});
+
+		const WrappedComponent = CTLViewsHoC(mockComponent);
+
+		// Hopefully this renders, and navigates and loads the
+		// new component.
+		await act(async () => {
+			render(
+				<MockAnalyticsProvider>
+					<MemoryRouter initialEntries={['/C99999/treatment/C2222']}>
+						<Routes>
+							<Route
+								path="/:codeOrPurl/:type/:interCodeOrPurl"
+								element={
+									<WrappedComponent
+										redirectPath={mockRedirectPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+							/>
+						</Routes>
+					</MemoryRouter>
+				</MockAnalyticsProvider>
+			);
+		});
+
+		// Total API calls for first render, and redirect
+		expect(getListingInformationById.mock.calls).toHaveLength(3);
+		expect(getTrialType.mock.calls).toHaveLength(2);
+		expect(getListingInformationByName.mock.calls).toHaveLength(1);
+
+		// First render API Calls
+		expect(getListingInformationById.mock.calls[0][1]).toEqual(['C99999']);
+		expect(getListingInformationById.mock.calls[1][1]).toEqual(['C2222']);
+		expect(getTrialType.mock.calls[0][1]).toEqual('treatment');
+
+		// After redirect API Calls
+		expect(getListingInformationById.mock.calls[2][1]).toEqual(['C99999']);
+		expect(getTrialType.mock.calls[1][1]).toEqual('treatment');
+		// Note the is happens after redirect
+		expect(getListingInformationByName.mock.calls[0][1]).toEqual(
+			'multi-id-concept'
+		);
+
+		// There should only be 1 call to our component as the HoC would have:
+		// Fetched the ID, then redirected, then fetched the second, then it
+		// would render our wrapped component.
+		expect(mockComponent.mock.calls).toHaveLength(1);
+		const { data: call1data } = mockComponent.mock.calls[0][0];
+
+		expect(call1data).toEqual([
+			CONCEPT_NO_PURL,
+			TRIAL_TYPE_TREATMENT,
+			CONCEPT_MULTI_ID,
+		]);
+	});
+
+	// For both of these tests, your wrapped component would have to explicitly
+	// call a navigate function. In these examples it is expected that the
+	// wrapped component would actually, and correctly, be called twice.
+	// These tests should not trigger a redirect based on ID.
+
+	// TODO: Add a test for one ID to another.
+	it('should handle the request for a concept, and then handle a navigate to another concept', async () => {
+		getListingInformationByName.mockReturnValueOnce(CONCEPT_BREAST_CANCER);
+
+		getListingInformationById.mockReturnValueOnce(CONCEPT_NO_PURL);
+
+		// We use RedirectPath to figure out the correct route for
+		// a redirect. This assumes /:codeOrPurl which matches our
+		// route below.
+		const mockRedirectPath = jest.fn().mockImplementationOnce(() => {
+			throw new Error(
+				'I should not be getting called here, but this is required.'
+			);
+		});
+
+		// This component will force a navigation
+		const mockComponent = jest.fn(({ data }) => {
+			const navigate = useNavigate();
+			useEffect(() => {
+				// Only navigate if the concept is our first one.
+				if (data.some((concept) => concept.conceptId.includes('C4872'))) {
+					navigate('/C99999', {
+						replace: true,
+					});
+				}
+			}, []);
+			return <></>;
+		});
+
+		const WrappedComponent = CTLViewsHoC(mockComponent);
+
+		// Hopefully this renders, and navigates and loads the
+		// new component.
+		await act(async () => {
+			render(
+				<MockAnalyticsProvider>
+					<MemoryRouter initialEntries={['/breast-cancer']}>
+						<Routes>
+							<Route
+								path="/:codeOrPurl"
+								element={
+									<WrappedComponent
+										redirectPath={mockRedirectPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+							/>
+						</Routes>
+					</MemoryRouter>
+				</MockAnalyticsProvider>
+			);
+		});
+
+		// First request
+		expect(getListingInformationByName.mock.calls).toHaveLength(1);
+		expect(getListingInformationByName.mock.calls[0][1]).toEqual(
+			'breast-cancer'
+		);
+
+		// Call after redirect
+		expect(getListingInformationById.mock.calls).toHaveLength(1);
+		expect(getListingInformationById.mock.calls[0][1]).toEqual(['C99999']);
+
+		// This should have only 2 calls. One for the Purl, and one
+		// for the C-code without the purl.
+		expect(mockComponent.mock.calls).toHaveLength(2);
+		const { data: call1data } = mockComponent.mock.calls[0][0];
+		const { data: call2data } = mockComponent.mock.calls[1][0];
+
+		expect(call1data).toEqual([CONCEPT_BREAST_CANCER]);
+
+		expect(call2data).toEqual([CONCEPT_NO_PURL]);
+	});
+
+	// TODO: Add a test for route with 1 param to a route with 2 params
+	it('should handle the request for a concept, and then handle a navigate to concept plus type', async () => {
+		getListingInformationById.mockImplementation((client, ids) => {
+			if (ids.includes('C99999')) {
+				return CONCEPT_NO_PURL;
+			}
+		});
+
+		getTrialType.mockImplementation((client, trialType) => {
+			if (trialType === 'treatment') {
+				return TRIAL_TYPE_TREATMENT;
+			}
+		});
+
+		// This should not get called.
+		const mockRedirectPath = jest.fn().mockImplementationOnce(() => {
+			throw new Error(
+				'I should not be getting called here, but this is required.'
+			);
+		});
+
+		const mockComponentConcept = jest.fn(() => {
+			const navigate = useNavigate();
+			useEffect(() => {
+				navigate('/C99999/treatment', {
+					replace: true,
+				});
+			}, []);
+			return <></>;
+		});
+
+		const mockComponentConceptPlusType = jest.fn(() => {
+			return <>This would be the disease + type component.</>;
+		});
+
+		const WrappedComponentConcept = CTLViewsHoC(mockComponentConcept);
+		const WrappedComponentConceptPlusType = CTLViewsHoC(
+			mockComponentConceptPlusType
+		);
+
+		// Hopefully this renders, and navigates and loads the
+		// new component.
+		await act(async () => {
+			render(
+				<MockAnalyticsProvider>
+					<MemoryRouter initialEntries={['/C99999']}>
+						<Routes>
+							<Route
+								path="/:codeOrPurl"
+								element={
+									<WrappedComponentConcept
+										redirectPath={mockRedirectPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+							/>
+							<Route
+								path="/:codeOrPurl/:type"
+								element={
+									<WrappedComponentConceptPlusType
+										redirectPath={mockRedirectPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+							/>
+						</Routes>
+					</MemoryRouter>
+				</MockAnalyticsProvider>
+			);
+		});
+
+		// Total API calls for first render, and redirect
+		expect(getListingInformationById.mock.calls).toHaveLength(2);
+		expect(getTrialType.mock.calls).toHaveLength(1);
+
+		// First render API Calls
+		expect(getListingInformationById.mock.calls[0][1]).toEqual(['C99999']);
+
+		// After redirect API Calls
+		// TODO: With caching, there should only be a call to byId on the first render
+		expect(getListingInformationById.mock.calls[1][1]).toEqual(['C99999']);
+		expect(getTrialType.mock.calls[0][1]).toEqual('treatment');
+
+		// The mock component should only be called once as that would
+		// only be when the redirects have stopped. So 2 calls with a
+		// null is wrong.
+		expect(mockComponentConcept.mock.calls).toHaveLength(1);
+		const { data: conceptData } = mockComponentConcept.mock.calls[0][0];
+		expect(mockComponentConceptPlusType.mock.calls).toHaveLength(1);
+		const {
+			data: conceptTypeData,
+		} = mockComponentConceptPlusType.mock.calls[0][0];
+
+		expect(conceptData).toEqual([CONCEPT_NO_PURL]);
+
+		expect(conceptTypeData).toEqual([CONCEPT_NO_PURL, TRIAL_TYPE_TREATMENT]);
+	});
+});

--- a/src/views/hocReducer.js
+++ b/src/views/hocReducer.js
@@ -1,0 +1,124 @@
+import { convertObjectToBase64 } from '../utils/objects';
+
+// Action type declarations
+// Let's use some constants for our state var so we can handle
+// loading, loaded, 404 and error, without resorting to a reducer.
+export const hocStates = Object.freeze({
+	LOADING_STATE: 'loading_state',
+	LOADED_STATE: 'loaded_state',
+	NOTFOUND_STATE: 'notfound_state',
+	ERROR_STATE: 'error_state',
+	REDIR_STATE: 'redir_state',
+});
+
+// Action Names
+const SUCCESSFUL_FETCH = 'successful_fetch';
+const ERROR_OCCURRED = 'error_occurred';
+const RESET_LOADING = 'reset_loading';
+const REDIRECT_NEEDED = 'redirect_needed';
+const ENCOUNTERED_NOTFOUND = 'encountered_notfound';
+
+// Actions
+export const setLoading = () => {
+	return {
+		type: RESET_LOADING,
+	};
+};
+
+/**
+ * Updates the state to reflect a successful fetch from the API.
+ * @param {string} fetchActionsHash a hash of the actions array representing the API calls
+ * @param {Array<object>} fetchResponse the objects returned by the API for those calls
+ */
+export const setSuccessfulFetch = (fetchActionsHash, fetchResponse) => {
+	return {
+		type: SUCCESSFUL_FETCH,
+		payload: {
+			fetchActionsHash,
+			fetchResponse,
+		},
+	};
+};
+
+export const setRedirecting = () => {
+	return {
+		type: REDIRECT_NEEDED,
+	};
+};
+
+export const setFailedFetch = () => {
+	return {
+		type: ERROR_OCCURRED,
+	};
+};
+
+export const setNotFound = () => {
+	return {
+		type: ENCOUNTERED_NOTFOUND,
+	};
+};
+
+const getStatusByAction = (type) => {
+	switch (type) {
+		case SUCCESSFUL_FETCH:
+			return hocStates.LOADED_STATE;
+		case RESET_LOADING:
+			return hocStates.LOADING_STATE;
+		case ENCOUNTERED_NOTFOUND:
+			return hocStates.NOTFOUND_STATE;
+		case ERROR_OCCURRED:
+			return hocStates.ERROR_STATE;
+		case REDIRECT_NEEDED:
+			return hocStates.REDIR_STATE;
+	}
+};
+
+// Reducer
+export const hocReducer = (state = {}, action) => {
+	if (action.type === SUCCESSFUL_FETCH) {
+		// If the status has changed, then the data must have changed
+		// so return a new object
+		if (state.status !== hocStates.LOADED_STATE) {
+			return {
+				status: hocStates.LOADED_STATE,
+				listingData: action.payload.fetchResponse,
+				actionsHash: action.payload.fetchActionsHash,
+			};
+		} else {
+			// Status is the same, did the payload change, or are we trying to update
+			// the same object?
+			const newPayloadHash = convertObjectToBase64(action.payload);
+			const oldPayloadHash = convertObjectToBase64(state.listingData);
+			if (newPayloadHash === oldPayloadHash) {
+				// Same status, same object, same state
+				return state;
+			} else {
+				return {
+					status: hocStates.LOADED_STATE,
+					listingData: action.payload.fetchResponse,
+					actionsHash: action.payload.fetchActionsHash,
+				};
+			}
+		}
+	} else {
+		switch (action.type) {
+			case RESET_LOADING:
+			case ENCOUNTERED_NOTFOUND:
+			case ERROR_OCCURRED:
+			case REDIRECT_NEEDED: {
+				const status = getStatusByAction(action.type);
+				if (state.status === status && state.listingData === null) {
+					return state;
+				} else {
+					return {
+						status,
+						listingData: null,
+						fetchActionsHash: '',
+					};
+				}
+			}
+			default:
+				return state;
+		}
+	}
+};


### PR DESCRIPTION
- Added parameter checking for API actions to make sure the actions
  are called with correct data.
- Added support for hashing the list of fetch actions so the app
  does not re-render itself too many times. This is for both
  useListingSupport and for CTLViewHoc.
- Added a number of tests to handle all the use cases that the
  original approach failed on.

Closes #100