### PR TITLE
(#48) Add Caching for Listing Support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import './styles/app.scss';
 
 import { pageTypePatterns, textProperties } from './constants';
 import { useAppPaths } from './hooks';
+import { ListingSupportContextProvider } from './hooks/listingSupport';
 import { useStateValue } from './store/store';
 import {
 	CTLViewsHoC,
@@ -116,37 +117,39 @@ const App = () => {
 			// and both banner images are present, set the disease routes.
 			if (hasDiseasePatterns && hasBannerImages) {
 				dynamicRoutes = (
-					<Routes>
-						<Route
-							path={NoTrialsPath()}
-							element={
-								<WrappedNoTrials
-									redirectPath={NoTrialsPath}
-									routeParamMap={diseaseRouteParamMap}
-								/>
-							}
-							exact
-						/>
-						<Route
-							path={CodeOrPurlPath()}
-							element={
-								<WrappedDisease
-									redirectPath={CodeOrPurlPath}
-									routeParamMap={diseaseRouteParamMap}
-								/>
-							}
-						/>
-						<Route
-							path={CodeOrPurlWithTypeAndInterCodeOrPurlPath()}
-							element={
-								<WrappedDisease
-									redirectPath={CodeOrPurlWithTypeAndInterCodeOrPurlPath}
-									routeParamMap={diseaseRouteParamMap}
-								/>
-							}
-						/>
-						<Route path="/*" element={<PageNotFound />} />
-					</Routes>
+					<ListingSupportContextProvider>
+						<Routes>
+							<Route
+								path={NoTrialsPath()}
+								element={
+									<WrappedNoTrials
+										redirectPath={NoTrialsPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+								exact
+							/>
+							<Route
+								path={CodeOrPurlPath()}
+								element={
+									<WrappedDisease
+										redirectPath={CodeOrPurlPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+							/>
+							<Route
+								path={CodeOrPurlWithTypeAndInterCodeOrPurlPath()}
+								element={
+									<WrappedDisease
+										redirectPath={CodeOrPurlWithTypeAndInterCodeOrPurlPath}
+										routeParamMap={diseaseRouteParamMap}
+									/>
+								}
+							/>
+							<Route path="/*" element={<PageNotFound />} />
+						</Routes>
+					</ListingSupportContextProvider>
 				);
 			} else {
 				const params = getInvalidParams(hasDiseasePatterns, hasBannerImages);
@@ -183,28 +186,30 @@ const App = () => {
 			// If both banner images are present, set the intervention routes.
 			if (hasBannerImages) {
 				dynamicRoutes = (
-					<Routes>
-						<Route
-							path={NoTrialsPath()}
-							element={
-								<WrappedNoTrials
-									redirectPath={NoTrialsPath}
-									routeParamMap={interventionRouteParamMap}
-								/>
-							}
-							exact
-						/>
-						<Route
-							path={CodeOrPurlPath()}
-							element={
-								<WrappedIntervention
-									redirectPath={CodeOrPurlPath}
-									routeParamMap={interventionRouteParamMap}
-								/>
-							}
-						/>
-						<Route path="/*" element={<PageNotFound />} />
-					</Routes>
+					<ListingSupportContextProvider>
+						<Routes>
+							<Route
+								path={NoTrialsPath()}
+								element={
+									<WrappedNoTrials
+										redirectPath={NoTrialsPath}
+										routeParamMap={interventionRouteParamMap}
+									/>
+								}
+								exact
+							/>
+							<Route
+								path={CodeOrPurlPath()}
+								element={
+									<WrappedIntervention
+										redirectPath={CodeOrPurlPath}
+										routeParamMap={interventionRouteParamMap}
+									/>
+								}
+							/>
+							<Route path="/*" element={<PageNotFound />} />
+						</Routes>
+					</ListingSupportContextProvider>
 				);
 			} else {
 				dynamicRoutes = (

--- a/src/hooks/listingSupport/__tests__/listingSupportCache.test.js
+++ b/src/hooks/listingSupport/__tests__/listingSupportCache.test.js
@@ -1,0 +1,22 @@
+import { ListingSupportCache } from '../index';
+
+describe('ListingSupportCache', () => {
+	it('adds items', () => {
+		const cache = new ListingSupportCache();
+		expect(cache.keys()).toHaveLength(0);
+
+		cache.add('item1', { a: 'b' });
+		expect(cache.get('item1')).toEqual({ a: 'b' });
+	});
+
+	it('allows us to get multiple keys', () => {
+		const cache = new ListingSupportCache();
+		expect(cache.keys()).toHaveLength(0);
+
+		cache.add('item1', { a: 'b' });
+		cache.add('item2', { a: 'c' });
+		cache.add('item3', { a: 'd' });
+
+		expect(cache.keys()).toEqual(['item1', 'item2', 'item3']);
+	});
+});

--- a/src/hooks/listingSupport/__tests__/listingSupportContextProvider.test.js
+++ b/src/hooks/listingSupport/__tests__/listingSupportContextProvider.test.js
@@ -1,0 +1,45 @@
+import React, { useContext, useEffect } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
+import { ListingSupportContext, ListingSupportContextProvider } from '../index';
+
+describe('ListingSupportContextProvider', () => {
+	it('keeps cache between multiple routes', async () => {
+		const MockComponent = jest.fn().mockImplementation(() => {
+			const { cache } = useContext(ListingSupportContext);
+			const navigate = useNavigate();
+
+			useEffect(() => {
+				cache.add('item1', { a: 1 });
+				navigate('/othertest');
+			}, []);
+
+			return <div>The component</div>;
+		});
+
+		const MockComponent2 = jest.fn().mockImplementation(() => {
+			const { cache } = useContext(ListingSupportContext);
+
+			const cacheKeys = cache.keys().join(',');
+
+			return <div>Keys: {cacheKeys}</div>;
+		});
+
+		await act(() => {
+			render(
+				<ListingSupportContextProvider>
+					<MemoryRouter initialEntries={['/test']}>
+						<Routes>
+							<Route path="/test" element={<MockComponent />} />
+							<Route path="/othertest" element={<MockComponent2 />} />
+						</Routes>
+					</MemoryRouter>
+				</ListingSupportContextProvider>
+			);
+		});
+
+		expect(MockComponent.mock.calls).toHaveLength(1);
+		expect(MockComponent2.mock.calls).toHaveLength(1);
+		expect(screen.getByText('Keys: item1')).toBeInTheDocument();
+	});
+});

--- a/src/hooks/listingSupport/__tests__/reducer.test.js
+++ b/src/hooks/listingSupport/__tests__/reducer.test.js
@@ -5,14 +5,27 @@ import {
 	setLoading,
 	setAborted,
 } from '../actions';
+import { getListingInformationById as IdAction } from '../../../services/api/actions/getListingInformationById';
+
+const CONCEPT_NO_PURL = {
+	conceptId: ['C99999'],
+	name: {
+		label: 'No Purl Concept',
+		normalized: 'no purl concept',
+	},
+	prettyUrlName: null,
+};
 
 describe('listingSupport reducer', () => {
 	it('should handle successful fetch action', () => {
-		const actual = reducer({}, setSuccessfulFetch({ a: 1 }));
+		const actual = reducer(
+			{},
+			setSuccessfulFetch([IdAction({ ids: ['C99999'] })], [CONCEPT_NO_PURL])
+		);
 		expect(actual).toEqual({
 			loading: false,
 			error: null,
-			payload: { a: 1 },
+			payload: [CONCEPT_NO_PURL],
 			aborted: false,
 		});
 	});
@@ -40,6 +53,16 @@ describe('listingSupport reducer', () => {
 
 	it('should handle set aborted action', () => {
 		const actual = reducer({}, setAborted());
+		expect(actual).toEqual({
+			loading: false,
+			error: null,
+			payload: null,
+			aborted: true,
+		});
+	});
+
+	it('handles an initial state', () => {
+		const actual = reducer(undefined, setAborted());
 		expect(actual).toEqual({
 			loading: false,
 			error: null,

--- a/src/hooks/listingSupport/__tests__/updateCache.test.js
+++ b/src/hooks/listingSupport/__tests__/updateCache.test.js
@@ -1,0 +1,147 @@
+import { ListingSupportCache } from '../index';
+import { updateCache } from '../updateCache';
+import { getListingInformationById as IdAction } from '../../../services/api/actions/getListingInformationById';
+import { getListingInformationByName as NameAction } from '../../../services/api/actions/getListingInformationByName';
+import { getTrialType as TrialTypeAction } from '../../../services/api/actions/getTrialType';
+
+describe('updateCache', () => {
+	// Let's set up some API responses that we are going to reuse all over
+	// the place, which is end up being hard to read.
+	const CONCEPT_BREAST_CANCER = {
+		conceptId: ['C4872'],
+		name: {
+			label: 'Breast Cancer',
+			normalized: 'breast cancer',
+		},
+		prettyUrlName: 'breast-cancer',
+	};
+
+	const CONCEPT_MULTI_ID = {
+		conceptId: ['C1111', 'C2222'],
+		name: {
+			label: 'Multi-id Concept',
+			normalized: 'multi-id concept',
+		},
+		prettyUrlName: 'multi-id-concept',
+	};
+
+	const CONCEPT_NO_PURL = {
+		conceptId: ['C99999'],
+		name: {
+			label: 'No Purl Concept',
+			normalized: 'no purl concept',
+		},
+		prettyUrlName: null,
+	};
+
+	const TRIAL_TYPE_TREATMENT = {
+		prettyUrlName: 'treatment',
+		idString: 'treatment',
+		label: 'Treatment',
+	};
+
+	const TRIAL_TYPE_SUPP_CARE = {
+		prettyUrlName: 'supportive-care',
+		idString: 'supportive_care',
+		label: 'Supportive Care',
+	};
+
+	const DEFAULT_FETCH_RESPONSE = [
+		CONCEPT_MULTI_ID,
+		TRIAL_TYPE_TREATMENT,
+		CONCEPT_NO_PURL,
+	];
+
+	const DEFAULT_FETCH_ACTIONS = [
+		NameAction({ name: 'multi-id-concept' }),
+		TrialTypeAction({ trialType: 'treatment' }),
+		IdAction({ ids: ['C99999'] }),
+	];
+
+	// HACK: We should not be looking at ._cache, but for now to get this out
+	// the door it can stay. (Seeing as how this is the only thing that ever
+	// updates the cache...)
+
+	it('caches multiple responses correctly, with empty initial', () => {
+		const cache = new ListingSupportCache();
+
+		const expected = {
+			C1111: CONCEPT_MULTI_ID,
+			C2222: CONCEPT_MULTI_ID,
+			'multi-id-concept': CONCEPT_MULTI_ID,
+			treatment: TRIAL_TYPE_TREATMENT,
+			C99999: CONCEPT_NO_PURL,
+		};
+
+		updateCache(cache, DEFAULT_FETCH_ACTIONS, DEFAULT_FETCH_RESPONSE);
+		expect(cache._cache).toEqual(expected);
+	});
+
+	it('handles trials types with different id and pretty url', () => {
+		const cache = new ListingSupportCache();
+
+		const expected = {
+			supportive_care: TRIAL_TYPE_SUPP_CARE,
+			'supportive-care': TRIAL_TYPE_SUPP_CARE,
+		};
+
+		updateCache(
+			cache,
+			[TrialTypeAction({ trialType: 'supportive-care' })],
+			[TRIAL_TYPE_SUPP_CARE]
+		);
+		expect(cache._cache).toEqual(expected);
+	});
+
+	it('caches multiple responses correctly, when adding', () => {
+		const cache = new ListingSupportCache();
+		cache.add(CONCEPT_BREAST_CANCER.prettyUrlName, CONCEPT_BREAST_CANCER);
+		cache.add(CONCEPT_BREAST_CANCER.conceptId[0], CONCEPT_BREAST_CANCER);
+
+		const expected = {
+			'breast-cancer': CONCEPT_BREAST_CANCER,
+			C4872: CONCEPT_BREAST_CANCER,
+			C1111: CONCEPT_MULTI_ID,
+			C2222: CONCEPT_MULTI_ID,
+			'multi-id-concept': CONCEPT_MULTI_ID,
+			treatment: TRIAL_TYPE_TREATMENT,
+			C99999: CONCEPT_NO_PURL,
+		};
+
+		updateCache(cache, DEFAULT_FETCH_ACTIONS, DEFAULT_FETCH_RESPONSE);
+		expect(cache._cache).toEqual(expected);
+	});
+
+	it('handles cases when there are nothing to add', () => {
+		const cache = new ListingSupportCache();
+		cache.add('C99999', CONCEPT_NO_PURL);
+
+		updateCache(cache, [DEFAULT_FETCH_ACTIONS[2]], [DEFAULT_FETCH_RESPONSE[2]]);
+		// NOTE: This really should be "toBe" we want the memory address to be the same
+		expect(cache._cache).toEqual({ C99999: CONCEPT_NO_PURL });
+	});
+
+	it('caches multiple responses correctly, handles 404 for TT', () => {
+		const cache = new ListingSupportCache();
+
+		const expected = {
+			C1111: CONCEPT_MULTI_ID,
+			C2222: CONCEPT_MULTI_ID,
+			'multi-id-concept': CONCEPT_MULTI_ID,
+			C99999: CONCEPT_NO_PURL,
+		};
+
+		updateCache(cache, DEFAULT_FETCH_ACTIONS, [
+			CONCEPT_MULTI_ID,
+			null,
+			CONCEPT_NO_PURL,
+		]);
+		expect(cache._cache).toEqual(expected);
+	});
+
+	it('throws an error when fetch type is unknown', () => {
+		expect(() => {
+			updateCache({}, [{ type: 'chicken' }], [{}]);
+		}).toThrow('Unknown fetch action chicken');
+	});
+});

--- a/src/hooks/listingSupport/actions.js
+++ b/src/hooks/listingSupport/actions.js
@@ -5,10 +5,13 @@ export const FETCH_SUCCESS = 'FETCH_SUCCESS';
 export const FETCH_ERROR = 'FETCH_ERROR';
 
 // Actions
-export const setSuccessfulFetch = (payload) => {
+export const setSuccessfulFetch = (fetchActions, fetchResponse) => {
 	return {
 		type: FETCH_SUCCESS,
-		payload,
+		payload: {
+			fetchActions,
+			fetchResponse,
+		},
 	};
 };
 

--- a/src/hooks/listingSupport/index.js
+++ b/src/hooks/listingSupport/index.js
@@ -1,0 +1,4 @@
+export { ListingSupportContext } from './listingSupportContext';
+export { ListingSupportContextProvider } from './listingSupportContextProvider';
+export { default as ListingSupportCache } from './listingSupportCache';
+export { useListingSupport } from './useListingSupport';

--- a/src/hooks/listingSupport/listingSupportCache.js
+++ b/src/hooks/listingSupport/listingSupportCache.js
@@ -1,0 +1,35 @@
+/**
+ * Simple class to encapsulate a collection of cache items.
+ */
+export default class ListingSupportCache {
+	/**
+	 * Create an instance of ListingSupportCache
+	 */
+	constructor() {
+		this._cache = {};
+	}
+
+	/**
+	 * Adds or updates an item in the cache
+	 * @param {string} key the key for the item
+	 * @param {Object} value the value to cache
+	 */
+	add(key, value) {
+		this._cache[key] = value;
+	}
+
+	/**
+	 * Gets an item from the cache
+	 * @param {string} key the key for the item
+	 */
+	get(key) {
+		return this._cache[key];
+	}
+
+	/**
+	 * Gets all the keys from the cache.
+	 */
+	keys() {
+		return Object.keys(this._cache);
+	}
+}

--- a/src/hooks/listingSupport/listingSupportContext.js
+++ b/src/hooks/listingSupport/listingSupportContext.js
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+/**
+ * Context used by the useListingSupport hook.
+ */
+export const ListingSupportContext = createContext();

--- a/src/hooks/listingSupport/listingSupportContextProvider.js
+++ b/src/hooks/listingSupport/listingSupportContextProvider.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ListingSupportContext } from './listingSupportContext';
+import ListingSupportCache from './listingSupportCache';
+
+// Create an instance of the cache to be used by the context.
+const cache = new ListingSupportCache();
+
+/**
+ * Provider that sets up the ListingSupportContext for useListingSupport.
+ * @param {Object} props.children the child controls
+ */
+export const ListingSupportContextProvider = ({ children }) => {
+	return (
+		<ListingSupportContext.Provider value={{ cache }}>
+			{children}
+		</ListingSupportContext.Provider>
+	);
+};
+
+ListingSupportContextProvider.propTypes = {
+	children: PropTypes.node,
+};

--- a/src/hooks/listingSupport/reducer.js
+++ b/src/hooks/listingSupport/reducer.js
@@ -6,12 +6,12 @@ import {
 } from './actions';
 
 // Reducer
-const reducer = (state = {}, action) => {
+const reducer = (state = { _cache: {} }, action) => {
 	switch (action.type) {
 		case FETCH_SUCCESS:
 			return {
 				loading: false,
-				payload: action.payload,
+				payload: action.payload.fetchResponse,
 				error: null,
 				aborted: false,
 			};

--- a/src/hooks/listingSupport/updateCache.js
+++ b/src/hooks/listingSupport/updateCache.js
@@ -1,0 +1,80 @@
+/**
+ * Gets an object with the correct keys/values for this concept to be cached
+ * @param {Object} concept a listing-information response from the API
+ */
+const getCacheForConcept = (concept) => {
+	if (concept === null) {
+		return {};
+	} else {
+		return {
+			...concept.conceptId.reduce(
+				(ac, curr) => ({ ...ac, [curr]: concept }),
+				{}
+			),
+			...(concept.prettyUrlName ? { [concept.prettyUrlName]: concept } : {}),
+		};
+	}
+};
+
+/**
+ * Gets an object with the correct keys/values for this trialType to be cached
+ * @param {Object} trialType a trial-type response from the API
+ */
+const getCacheForTrialType = (trialType) => {
+	if (trialType === null) {
+		return {};
+	} else {
+		return {
+			[trialType.idString]: trialType,
+			...(trialType.prettyUrlName !== trialType.idString
+				? { [trialType.prettyUrlName]: trialType }
+				: {}),
+		};
+	}
+};
+
+/**
+ * Adds any responses from the API on the cache object that don't exist.
+ * @param {ListingSupportCache} cache an instance of a ListingSupportCache
+ * @param {Array<Object>} payload the collection of API responses.
+ */
+export const updateCache = (cache, fetchActions, fetchResponse) => {
+	// Get all the cache items for this set of fetches.
+	const cacheItems = fetchActions.reduce((ac, curr, idx) => {
+		switch (curr.type) {
+			case 'id':
+			case 'name': {
+				return {
+					...ac,
+					...getCacheForConcept(fetchResponse[idx]),
+				};
+			}
+			case 'trialType': {
+				return {
+					...ac,
+					...getCacheForTrialType(fetchResponse[idx]),
+				};
+			}
+			default:
+				throw new Error(`Unknown fetch action ${curr.type}`);
+		}
+	}, {});
+
+	// Get the keys for the existing cache.
+	const currentCacheKeys = cache.keys();
+
+	// Pluck out those items that are not currently in the cache.
+	const newCacheItems = Object.entries(cacheItems)
+		.filter(([key]) => !currentCacheKeys.includes(key))
+		.reduce((ac, [key, val]) => {
+			return {
+				...ac,
+				[key]: val,
+			};
+		}, {});
+
+	// Now we only want to update the cache if we have items to update.
+	for (const [key, val] of Object.entries(newCacheItems)) {
+		cache.add(key, val);
+	}
+};

--- a/src/views/__tests__/hocReducer.test.js
+++ b/src/views/__tests__/hocReducer.test.js
@@ -1,0 +1,113 @@
+import {
+	hocReducer,
+	setLoading,
+	setSuccessfulFetch,
+	setFailedFetch,
+	setNotFound,
+	setRedirecting,
+	hocStates,
+} from '../hocReducer';
+
+describe('hocReducer', () => {
+	it('sets successful from empty', () => {
+		const actual = hocReducer(
+			{},
+			setSuccessfulFetch('actionshash', [{ a: 1 }])
+		);
+		expect(actual).toEqual({
+			status: hocStates.LOADED_STATE,
+			listingData: [{ a: 1 }],
+			actionsHash: 'actionshash',
+		});
+	});
+
+	it('sets successful new data', () => {
+		const initialState = {
+			status: hocStates.LOADED_STATE,
+			listingData: [{ b: 2 }],
+			actionsHash: 'actionshash2',
+		};
+		const actual = hocReducer(
+			initialState,
+			setSuccessfulFetch('actionshash', [{ a: 1 }])
+		);
+		expect(actual).toEqual({
+			status: hocStates.LOADED_STATE,
+			listingData: [{ a: 1 }],
+			actionsHash: 'actionshash',
+		});
+	});
+
+	it('does not return new state with same data', () => {
+		const initialState = {
+			status: hocStates.LOADED_STATE,
+			listingData: [{ a: 1 }],
+			actionsHash: 'actionshash',
+		};
+		const actual = hocReducer(
+			initialState,
+			setSuccessfulFetch('actionshash', [{ a: 1 }])
+		);
+		expect(actual).toBe(initialState);
+	});
+
+	it('sets loading', () => {
+		const actual = hocReducer({}, setLoading());
+		expect(actual).toEqual({
+			status: hocStates.LOADING_STATE,
+			listingData: null,
+			actionsHash: '',
+		});
+	});
+
+	it('returns same object when resetting loading', () => {
+		const initialState = {
+			status: hocStates.LOADING_STATE,
+			listingData: null,
+			actionsHash: '',
+		};
+		const actual = hocReducer(initialState, setLoading());
+		expect(actual).toBe(initialState);
+	});
+
+	it('sets redirecting', () => {
+		const actual = hocReducer({}, setRedirecting());
+		expect(actual).toEqual({
+			status: hocStates.REDIR_STATE,
+			listingData: null,
+			actionsHash: '',
+		});
+	});
+
+	it('sets not found', () => {
+		const actual = hocReducer({}, setNotFound());
+		expect(actual).toEqual({
+			status: hocStates.NOTFOUND_STATE,
+			listingData: null,
+			actionsHash: '',
+		});
+	});
+
+	it('sets failed', () => {
+		const actual = hocReducer({}, setFailedFetch());
+		expect(actual).toEqual({
+			status: hocStates.ERROR_STATE,
+			listingData: null,
+			actionsHash: '',
+		});
+	});
+
+	it('should return the same state if unknown action', () => {
+		const initialState = { a: 1 };
+		expect(hocReducer(initialState, { type: 'chicken' })).toBe(initialState);
+	});
+
+	it('handles an initial state', () => {
+		const actual = hocReducer(undefined, setLoading());
+		expect(actual).toEqual({
+			status: hocStates.LOADING_STATE,
+			listingData: null,
+			actionsHash: '',
+		});
+	});
+});

--- a/src/views/hocReducer.js
+++ b/src/views/hocReducer.js
@@ -58,10 +58,8 @@ export const setNotFound = () => {
 	};
 };
 
-const getStatusByAction = (type) => {
+const getNonLoadedStatusByAction = (type) => {
 	switch (type) {
-		case SUCCESSFUL_FETCH:
-			return hocStates.LOADED_STATE;
 		case RESET_LOADING:
 			return hocStates.LOADING_STATE;
 		case ENCOUNTERED_NOTFOUND:
@@ -87,9 +85,14 @@ export const hocReducer = (state = {}, action) => {
 		} else {
 			// Status is the same, did the payload change, or are we trying to update
 			// the same object?
-			const newPayloadHash = convertObjectToBase64(action.payload);
-			const oldPayloadHash = convertObjectToBase64(state.listingData);
-			if (newPayloadHash === oldPayloadHash) {
+			const newResponseHash = convertObjectToBase64(
+				action.payload.fetchResponse
+			);
+			const oldResponseHash = convertObjectToBase64(state.listingData);
+			if (
+				newResponseHash === oldResponseHash &&
+				action.payload.fetchActionsHash === state.actionsHash
+			) {
 				// Same status, same object, same state
 				return state;
 			} else {
@@ -106,14 +109,18 @@ export const hocReducer = (state = {}, action) => {
 			case ENCOUNTERED_NOTFOUND:
 			case ERROR_OCCURRED:
 			case REDIRECT_NEEDED: {
-				const status = getStatusByAction(action.type);
-				if (state.status === status && state.listingData === null) {
+				const status = getNonLoadedStatusByAction(action.type);
+				if (
+					state.status === status &&
+					state.listingData === null &&
+					state.actionsHash === ''
+				) {
 					return state;
 				} else {
 					return {
 						status,
 						listingData: null,
-						fetchActionsHash: '',
+						actionsHash: '',
 					};
 				}
 			}


### PR DESCRIPTION
- This ended up needing a context and provider to store the cache. This
   is due to the fact that we create multiple instances of the HoC, and
   the useListingSupport state is lost across those instances.

Closes #48 