### PR TITLE
(#94) CIS Banner in IE

### DIFF
--- a/src/components/atomic/CISBanner/CISBanner.jsx
+++ b/src/components/atomic/CISBanner/CISBanner.jsx
@@ -28,7 +28,7 @@ const CISBanner = ({ onLiveHelpClick }) => {
 				<source srcSet={cisBannerImgUrlSmall} media="(max-width: 640px)" />
 				<source srcSet={cisBannerImgUrlLarge} />
 				<img
-					srcSet={cisBannerImgUrlSmall}
+					src={cisBannerImgUrlLarge}
 					alt="Questions? Chat with an information specialist"
 				/>
 			</picture>


### PR DESCRIPTION
Closes #94

* Update syntax for picture element in CISBanner - fixes browser issues