### PR TITLE
(#182) Update location info utility to use new clinicaltrials.gov links

### DIFF
--- a/src/utils/__tests__/getLocationInfoFromSites.test.js
+++ b/src/utils/__tests__/getLocationInfoFromSites.test.js
@@ -127,7 +127,7 @@ describe('getLocationInfoFromSites', () => {
 
 		const jsxPartial = (
 			<a
-				href={`https://www.clinicaltrials.gov/show/${nctId}`}
+				href={`https://www.clinicaltrials.gov/study/${nctId}`}
 				rel="noopener noreferrer"
 				target="_blank">
 				ClinicalTrials.gov
@@ -181,7 +181,7 @@ describe('getLocationInfoFromSites', () => {
 	});
 
 	test('should return expected string when recruitment status is "Completed, Closed_to_accrual, Administratively_complete, Closed_to_accrual_and_intervention, or Withdrawn"', () => {
-		const siteLinkCT = `https://www.clinicaltrials.gov/show/${nctId}`;
+		const siteLinkCT = `https://www.clinicaltrials.gov/study/${nctId}`;
 		const sitesRecruitmentStatus = [
 			{
 				org_country: 'United States',

--- a/src/utils/getLocationInfoFromSites.js
+++ b/src/utils/getLocationInfoFromSites.js
@@ -17,7 +17,7 @@ export const getLocationInfoFromSites = (
 ) => {
 	let totalUSLocations = 0;
 	let lastUSLocationSite = 0;
-	const siteLinkCT = `https://www.clinicaltrials.gov/show/${nctId}`;
+	const siteLinkCT = `https://www.clinicaltrials.gov/study/${nctId}`;
 
 	// Filter list of sites by recruitment status before deriving location
 	const filteredSites = sites?.filter((site) => {


### PR DESCRIPTION
- Updated the getLocationInfoFromSites utility to use the new URL structure
Closes #182