### PR TITLE
(#202) Missing prerender-status-code on API error

### DIFF
--- a/cypress/e2e/ErrorPage/ErrorPage.feature
+++ b/cypress/e2e/ErrorPage/ErrorPage.feature
@@ -1,0 +1,22 @@
+Feature: As a user, when the listing API encounters and error, I am presented with an error page
+
+    Scenario: Display error page when a user views a manual listing page that encounters a CTS API error
+			Given "trialListingPageType" is set to "Manual"
+			And "cisBannerImgUrlLarge" is set to null
+			And "cisBannerImgUrlSmall" is set to null
+			And the CTS API is responding with a server error
+			Given the user navigates to "/?cfg=4"
+			Then the title tag should be "Errors Occurred"
+			And the page contains meta tags with the following names
+					| name                  | content |
+					| prerender-status-code | 500     |
+
+Scenario: Display error page when a user views a dynamic listing page that encounters a CTS API error
+  Given "trialListingPageType" is set to "Disease"
+  And "dynamicListingPatterns" object is set to "Disease"
+  And the CTS API is responding with a server error
+  Given the user navigates to "/C4872?cfg=0"
+  Then the title tag should be "Errors Occurred"
+  And the page contains meta tags with the following names
+   | name                  | content |
+   | prerender-status-code | 500     |

--- a/cypress/e2e/common/index.js
+++ b/cypress/e2e/common/index.js
@@ -42,6 +42,13 @@ Given('the user navigates to {string}', (destURL) => {
 	cy.visit(destURL);
 });
 
+// Used when we don't want to automatically fail the test when non-200 responses are encountered.
+Given('the user navigates to {string} with error handling', (destURL) => {
+	cy.visit(destURL, {
+		failOnStatusCode: false
+	});
+});
+
 Given('user is viewing the no results found page on any site', () => {
 	cy.visit('/?swKeyword=achoo');
 });
@@ -93,6 +100,25 @@ Then('the user gets an error page that reads {string}', (errorMessage) => {
 
 And('the page displays {string}', (text) => {
 	cy.get('#NCI-app-root').contains(text);
+});
+
+// Intercepts CTS API Calls
+Cypress.Commands.add("triggerServerError", () => {
+	cy.intercept('/cts/mock-api/v2/*', {
+		statusCode: 500
+	}).as('mockApiError');
+
+	cy.intercept('/cts/proxy-api/v2/*', {
+		statusCode: 500,
+	}).as('proxyApiError');
+
+	cy.intercept('https://clinicaltrialsapi.cancer.gov/api/v2/*', {
+		statusCode: 500,
+	}).as('ctsApiError');
+});
+
+And('the CTS API is responding with a server error', () => {
+	cy.triggerServerError();
 });
 
 /*

--- a/src/views/ErrorBoundary/ErrorPage.jsx
+++ b/src/views/ErrorBoundary/ErrorPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Helmet } from 'react-helmet';
 import { useTracking } from 'react-tracking';
 
 import { useStateValue } from '../../store/store';
@@ -21,10 +22,24 @@ const ErrorPage = () => {
 		});
 	}, []);
 
+	const renderHelmet = () => {
+		return (
+			<Helmet>
+				<title>Errors Occurred</title>
+				<meta property="dcterms.subject" content="Error Pages" />
+				<meta property="dcterms.type" content="errorpage" />
+				<meta name="prerender-status-code" content="500" />
+			</Helmet>
+		);
+	};
+
 	return (
-		<div className="error-container">
-			<h1>{i18n.errorPageText[language]}</h1>
-		</div>
+		<>
+			{renderHelmet()}
+			<div className="error-container">
+				<h1>{i18n.errorPageText[language]}</h1>
+			</div>
+		</>
 	);
 };
 


### PR DESCRIPTION
- Added renderHelmet with correct meta tag to ErrorPage.jsx

Closes #202