### PR TITLE
(#222) Reflect page number in canonical URLs.

### DIFF
--- a/cypress/e2e/DiseaseOnly/DiseaseCode.feature
+++ b/cypress/e2e/DiseaseOnly/DiseaseCode.feature
@@ -21,9 +21,9 @@ Feature: As a user, I would like to view the trial results for a disease listing
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                               |
       | og:title       | Breast Cancer Clinical Trials                                                                                                         |
-      | og:url         | http://localhost:3000/breast-cancer                                                                                                   |
+      | og:url         | http://localhost:3000/breast-cancer?pn=1                                                                                              |
       | og:description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials for breast cancer. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                               |
       | description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials for breast cancer. |
-    And there is a canonical link with the href "https://www.cancer.gov/breast-cancer"
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer?pn=1"

--- a/cypress/e2e/DiseaseOnly/DiseasePrettyURLName.feature
+++ b/cypress/e2e/DiseaseOnly/DiseasePrettyURLName.feature
@@ -32,12 +32,12 @@ Feature: As a user, I would like to view the trial results for a disease listing
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                               |
       | og:title       | Breast Cancer Clinical Trials                                                                                                         |
-      | og:url         | http://localhost:3000/breast-cancer                                                                                                   |
+      | og:url         | http://localhost:3000/breast-cancer?pn=1                                                                                              |
       | og:description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials for breast cancer. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                               |
       | description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials for breast cancer. |
-    And there is a canonical link with the href "https://www.cancer.gov/breast-cancer"
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer?pn=1"
     And meta tag with a "name" "prerender-status-code" does not exist
 
   Scenario: Mobile and Tablet Pager Display

--- a/cypress/e2e/DiseaseTrialType/DiseaseTypeIDString.feature
+++ b/cypress/e2e/DiseaseTrialType/DiseaseTypeIDString.feature
@@ -22,6 +22,10 @@ Feature: As a user, I would like to view the trial results for a disease listing
     When user clicks on "Next >" button
     Then the user is redirected to "/breast-cancer/supportive-care" with query parameters "cfg=0&pn=2"
     And user is brought to the top of a page
+		And the page contains meta tags with the following properties
+			| property       | content                                                                                                                                               |
+			| og:url         | http://localhost:3000/breast-cancer/supportive-care?pn=2                                                                                              |
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care?pn=2"
 
   Scenario: View disease trial type listing page metadata with trial type ID string parameter
     Given "trialListingPageType" is set to "Disease"
@@ -32,12 +36,12 @@ Feature: As a user, I would like to view the trial results for a disease listing
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                                               |
       | og:title       | Supportive Care Clinical Trials for Breast Cancer                                                                                                     |
-      | og:url         | http://localhost:3000/breast-cancer/supportive-care                                                                                                   |
+      | og:url         | http://localhost:3000/breast-cancer/supportive-care?pn=1                                                                                              |
       | og:description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find supportive care clinical trials for breast cancer. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                                               	 |
       | description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find supportive care clinical trials for breast cancer. 	 |
-    And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care"
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care?pn=1"
 
 	Scenario: Mobile and Tablet Pager Display
     Given "trialListingPageType" is set to "Disease"
@@ -60,3 +64,7 @@ Feature: As a user, I would like to view the trial results for a disease listing
     When user clicks on "Next >" button
     Then the user is redirected to "/breast-cancer/supportive-care" with query parameters "cfg=0&pn=2"
     And user is brought to the top of a page
+		And the page contains meta tags with the following properties
+			| property | content                                                  |
+			| og:url   | http://localhost:3000/breast-cancer/supportive-care?pn=2 |
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care?pn=2"

--- a/cypress/e2e/DiseaseTrialType/DiseaseTypePrettyURLName.feature
+++ b/cypress/e2e/DiseaseTrialType/DiseaseTypePrettyURLName.feature
@@ -22,6 +22,10 @@ Feature: As a user, I would like to view the trial results for a disease listing
     When user clicks on "Next >" button
     Then the user is redirected to "/breast-cancer/supportive-care" with query parameters "cfg=0&pn=2"
     And user is brought to the top of a page
+		And the page contains meta tags with the following properties
+			| property | content                                                  |
+			| og:url   | http://localhost:3000/breast-cancer/supportive-care?pn=2 |
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care?pn=2"
 
 
   Scenario: View disease trial type listing page metadata with pretty URL name parameters
@@ -33,12 +37,12 @@ Feature: As a user, I would like to view the trial results for a disease listing
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                                               |
       | og:title       | Supportive Care Clinical Trials for Breast Cancer                                                                                                     |
-      | og:url         | http://localhost:3000/breast-cancer/supportive-care                                                                                                   |
+      | og:url         | http://localhost:3000/breast-cancer/supportive-care?pn=1                                                                                              |
       | og:description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find supportive care clinical trials for breast cancer. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                                                  |
       | description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find supportive care clinical trials for breast cancer. 	 |
-    And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care"
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care?pn=1"
     And meta tag with a "name" "prerender-status-code" does not exist
 
   Scenario: Mobile and Tablet Pager Display
@@ -62,3 +66,7 @@ Feature: As a user, I would like to view the trial results for a disease listing
     When user clicks on "Next >" button
     Then the user is redirected to "/breast-cancer/supportive-care" with query parameters "cfg=0&pn=2"
     And user is brought to the top of a page
+		And the page contains meta tags with the following properties
+			| property | content                                                  |
+			| og:url   | http://localhost:3000/breast-cancer/supportive-care?pn=2 |
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/supportive-care?pn=2"

--- a/cypress/e2e/DiseaseTrialTypeIntervention/DiseaseTypeInterventionCode.feature
+++ b/cypress/e2e/DiseaseTrialTypeIntervention/DiseaseTypeInterventionCode.feature
@@ -21,9 +21,9 @@ Feature: As a user, I would like to view the trial results for a disease listing
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                                                                   |
       | og:title       | Treatment Clinical Trials for Breast Cancer Using Trastuzumab                                                                                                             |
-      | og:url         | http://localhost:3000/breast-cancer/treatment/trastuzumab                                                                                                                 |
+      | og:url         | http://localhost:3000/breast-cancer/treatment/trastuzumab?pn=1                                                                                                            |
       | og:description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials testing trastuzumab in the treatment of breast cancer. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                                                                   |
       | description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials testing trastuzumab in the treatment of breast cancer. |
-    And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/treatment/trastuzumab"
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/treatment/trastuzumab?pn=1"

--- a/cypress/e2e/DiseaseTrialTypeIntervention/DiseaseTypeInterventionPrettyURLName.feature
+++ b/cypress/e2e/DiseaseTrialTypeIntervention/DiseaseTypeInterventionPrettyURLName.feature
@@ -19,6 +19,10 @@ Feature: As a user, I would like to view the trial results for a disease listing
     When user clicks on "Next >" button
     Then the user is redirected to "/breast-cancer/treatment/trastuzumab" with query parameters "cfg=0&pn=2"
     And user is brought to the top of a page
+		And the page contains meta tags with the following properties
+			| property | content                                                  |
+			| og:url   | http://localhost:3000/breast-cancer/treatment/trastuzumab?pn=2 |
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/treatment/trastuzumab?pn=2"
 
 
   Scenario: View disease trial type and intervention listing page metadata with pretty URL name parameter
@@ -30,12 +34,12 @@ Feature: As a user, I would like to view the trial results for a disease listing
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                                                                   |
       | og:title       | Treatment Clinical Trials for Breast Cancer Using Trastuzumab                                                                                                             |
-      | og:url         | http://localhost:3000/breast-cancer/treatment/trastuzumab                                                                                                                 |
+      | og:url         | http://localhost:3000/breast-cancer/treatment/trastuzumab?pn=1                                                                                                            |
       | og:description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials testing trastuzumab in the treatment of breast cancer. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                                                                   |
       | description | NCI supports clinical trials studying new and more effective ways to detect and treat cancer. Find clinical trials testing trastuzumab in the treatment of breast cancer. |
-    And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/treatment/trastuzumab"
+		And there is a canonical link with the href "https://www.cancer.gov/breast-cancer/treatment/trastuzumab?pn=1"
     And meta tag with a "name" "prerender-status-code" does not exist
 
   Scenario: Mobile and Tablet Pager Display

--- a/cypress/e2e/Intervention/InterventionCode.feature
+++ b/cypress/e2e/Intervention/InterventionCode.feature
@@ -21,9 +21,9 @@ Feature: As a user, I would like to view the trial results for an intervention l
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                        |
       | og:title       | Clinical Trials Using Trastuzumab                                                                                              |
-      | og:url         | http://localhost:3000/trastuzumab                                                                                              |
+      | og:url         | http://localhost:3000/trastuzumab?pn=1                                                                                         |
       | og:description | NCI supports clinical trials that test new and more effective ways to treat cancer. Find clinical trials studying trastuzumab. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                        |
       | description | NCI supports clinical trials that test new and more effective ways to treat cancer. Find clinical trials studying trastuzumab. |
-    And there is a canonical link with the href "https://www.cancer.gov/trastuzumab"
+		And there is a canonical link with the href "https://www.cancer.gov/trastuzumab?pn=1"

--- a/cypress/e2e/Intervention/InterventionCodeUglyToPrettyURL.feature
+++ b/cypress/e2e/Intervention/InterventionCodeUglyToPrettyURL.feature
@@ -6,9 +6,9 @@ Feature: As the system, I want to be able to redirect users to pretty URLs for t
 		Given the user navigates to "/C1647?cfg=1"
 		Then the user is redirected to "/trastuzumab?cfg=1&redirect=true"
 		And the page contains meta tags with the following names
-				| name                  | content 																		 |
-				| prerender-status-code | 301     																		 |
-				| prerender-header		  | Location: http://localhost:3000/trastuzumab  |
+				| name                  | content 																	  |
+				| prerender-status-code | 301     																	  |
+				| prerender-header		  | Location: http://localhost:3000/trastuzumab |
 
 	Scenario: Page goes to prettyURL, without appending redirect=true, when not given a c-code
 		Given "trialListingPageType" is set to "Intervention"

--- a/cypress/e2e/Intervention/InterventionPrettyURLName.feature
+++ b/cypress/e2e/Intervention/InterventionPrettyURLName.feature
@@ -29,12 +29,12 @@ Feature: As a user, I would like to view the trial results for an intervention l
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                        |
       | og:title       | Clinical Trials Using Trastuzumab                                                                                              |
-      | og:url         | http://localhost:3000/trastuzumab                                                                                              |
+      | og:url         | http://localhost:3000/trastuzumab?pn=1                                                                                         |
       | og:description | NCI supports clinical trials that test new and more effective ways to treat cancer. Find clinical trials studying trastuzumab. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                        |
       | description | NCI supports clinical trials that test new and more effective ways to treat cancer. Find clinical trials studying trastuzumab. |
-    And there is a canonical link with the href "https://www.cancer.gov/trastuzumab"
+    And there is a canonical link with the href "https://www.cancer.gov/trastuzumab?pn=1"
 
   Scenario: Mobile and Tablet Pager Display
     Given "trialListingPageType" is set to "Intervention"

--- a/cypress/e2e/InterventionTrialType/InterventionTrialTypeCode.feature
+++ b/cypress/e2e/InterventionTrialType/InterventionTrialTypeCode.feature
@@ -21,9 +21,9 @@ Feature: As a user, I would like to view the trial results for an intervention l
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                                                 |
       | og:title       | Treatment Clinical Trials Using Trastuzumab                                                                                                             |
-      | og:url         | http://localhost:3000/trastuzumab/treatment                                                                                                             |
+      | og:url         | http://localhost:3000/trastuzumab/treatment?pn=1                                                                                                        |
       | og:description | NCI supports clinical trials studying new and more effective ways to treat cancer. Find clinical trials testing treatment methods that use trastuzumab. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                                                 |
       | description | NCI supports clinical trials studying new and more effective ways to treat cancer. Find clinical trials testing treatment methods that use trastuzumab. |
-    And there is a canonical link with the href "https://www.cancer.gov/trastuzumab/treatment"
+		And there is a canonical link with the href "https://www.cancer.gov/trastuzumab/treatment?pn=1"

--- a/cypress/e2e/InterventionTrialType/InterventionTrialTypePrettyURLName.feature
+++ b/cypress/e2e/InterventionTrialType/InterventionTrialTypePrettyURLName.feature
@@ -20,6 +20,10 @@ Feature: As a user, I would like to view the trial results for an intervention l
     When user clicks on "Next >" button
     Then the user is redirected to "/trastuzumab/treatment" with query parameters "cfg=1&pn=2"
     And user is brought to the top of a page
+		And the page contains meta tags with the following properties
+			| property | content                                              |
+			| og:url   | http://localhost:3000/trastuzumab/treatment?pn=2     |
+		And there is a canonical link with the href "https://www.cancer.gov/trastuzumab/treatment?pn=2"
 
   Scenario: View intervention listing page metadata with pretty URL name parameter
     Given "trialListingPageType" is set to "Intervention"
@@ -30,12 +34,12 @@ Feature: As a user, I would like to view the trial results for an intervention l
     And the page contains meta tags with the following properties
       | property       | content                                                                                                                                                 |
       | og:title       | Treatment Clinical Trials Using Trastuzumab                                                                                                             |
-      | og:url         | http://localhost:3000/trastuzumab/treatment                                                                                                             |
+      | og:url         | http://localhost:3000/trastuzumab/treatment?pn=1                                                                                                        |
       | og:description | NCI supports clinical trials studying new and more effective ways to treat cancer. Find clinical trials testing treatment methods that use trastuzumab. |
     And the page contains meta tags with the following names
       | name        | content                                                                                                                                                 |
       | description | NCI supports clinical trials studying new and more effective ways to treat cancer. Find clinical trials testing treatment methods that use trastuzumab. |
-    And there is a canonical link with the href "https://www.cancer.gov/trastuzumab/treatment"
+    And there is a canonical link with the href "https://www.cancer.gov/trastuzumab/treatment?pn=1"
     And meta tag with a "name" "prerender-status-code" does not exist
 
   Scenario: Mobile and Tablet Pager Display

--- a/cypress/e2e/Manual/AdultMetastaticBrainTumor.feature
+++ b/cypress/e2e/Manual/AdultMetastaticBrainTumor.feature
@@ -33,12 +33,12 @@ Feature: As a user, I would like to view the trial results for a manual listing 
     And the page contains meta tags with the following properties
       | property       | content                                                      |
       | og:title       | Clinical Trials for Adult Metastatic Brain Tumors            |
-      | og:url         | http://localhost:3000/                                       |
+      | og:url         | http://localhost:3000/?pn=1                                  |
       | og:description | Find clinical trials to treat adult metastatic brain tumors. |
     And the page contains meta tags with the following names
       | name        | content                                                      |
       | description | Find clinical trials to treat adult metastatic brain tumors. |
-    And there is a canonical link with the href "https://www.cancer.gov/"
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=1"
 
   Scenario: User is able to navigate through pages on manual listings
     Given "trialListingPageType" is set to "Manual"
@@ -70,6 +70,10 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "2" is highlighted
+		And the page contains meta tags with the following properties
+			| property | content                                          |
+			| og:url   | http://localhost:3000/?pn=2                      |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=2"
     When user clicks on "Next >" button
     Then pager displays the following navigation options
       | pages      |
@@ -83,7 +87,11 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "3" is highlighted
-    When user clicks on "Next >" button
+		And the page contains meta tags with the following properties
+			| property | content                     |
+			| og:url   | http://localhost:3000/?pn=3 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=3"
+		When user clicks on "Next >" button
     Then pager displays the following navigation options
       | pages      |
       | < Previous |
@@ -97,7 +105,11 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "4" is highlighted
-    When user clicks on "Next >" button
+		And the page contains meta tags with the following properties
+			| property | content                     |
+			| og:url   | http://localhost:3000/?pn=4 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=4"
+		When user clicks on "Next >" button
     Then pager displays the following navigation options
       | pages      |
       | < Previous |
@@ -112,7 +124,11 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "5" is highlighted
-    When user clicks on "11" button
+		And the page contains meta tags with the following properties
+			| property | content                     |
+			| og:url   | http://localhost:3000/?pn=5 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=5"
+		When user clicks on "11" button
     Then pager displays the following navigation options
       | pages      |
       | < Previous |
@@ -122,7 +138,11 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 10         |
       | 11         |
     And the page "11" is highlighted
-    When user clicks on "< Previous" button
+		And the page contains meta tags with the following properties
+			| property | content                      |
+			| og:url   | http://localhost:3000/?pn=11 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=11"
+		When user clicks on "< Previous" button
     Then pager displays the following navigation options
       | pages      |
       | < Previous |
@@ -134,7 +154,11 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "10" is highlighted
-    When user clicks on "< Previous" button
+		And the page contains meta tags with the following properties
+			| property | content                      |
+			| og:url   | http://localhost:3000/?pn=10 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=10"
+		When user clicks on "< Previous" button
     Then pager displays the following navigation options
       | pages      |
       | < Previous |
@@ -147,7 +171,11 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "9" is highlighted
-    When user clicks on "< Previous" button
+		And the page contains meta tags with the following properties
+			| property | content                     |
+			| og:url   | http://localhost:3000/?pn=9 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=9"
+		When user clicks on "< Previous" button
     Then pager displays the following navigation options
       | pages      |
       | < Previous |
@@ -161,7 +189,11 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "8" is highlighted
-    When user clicks on "< Previous" button
+		And the page contains meta tags with the following properties
+			| property | content                     |
+			| og:url   | http://localhost:3000/?pn=8 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=8"
+		When user clicks on "< Previous" button
     Then pager displays the following navigation options
       | pages      |
       | < Previous |
@@ -176,6 +208,10 @@ Feature: As a user, I would like to view the trial results for a manual listing 
       | 11         |
       | Next >     |
     And the page "7" is highlighted
+		And the page contains meta tags with the following properties
+			| property | content                     |
+			| og:url   | http://localhost:3000/?pn=7 |
+		And there is a canonical link with the href "https://www.cancer.gov/?pn=7"
 
   Scenario: View manual listing page with no pager (when total results is less than items per page )
     Given "trialListingPageType" is set to "Manual"

--- a/src/views/Disease/Disease.jsx
+++ b/src/views/Disease/Disease.jsx
@@ -172,6 +172,7 @@ const Disease = ({ routeParamMap, routePath, data }) => {
 	};
 
 	const renderHelmet = () => {
+		const pathAndPage = window.location.pathname + `?pn=${pager.page}`;
 		const prerenderHeader = baseHost + window.location.pathname;
 		const status = location.state?.redirectStatus;
 
@@ -179,10 +180,10 @@ const Disease = ({ routeParamMap, routePath, data }) => {
 			<Helmet>
 				<title>{`${replacedText.browserTitle} - ${siteName}`}</title>
 				<meta property="og:title" content={`${replacedText.pageTitle}`} />
-				<meta property="og:url" content={baseHost + window.location.pathname} />
+				<meta property="og:url" content={baseHost + pathAndPage} />
 				<meta name="description" content={replacedText.metaDescription} />
 				<meta property="og:description" content={replacedText.metaDescription} />
-				<link rel="canonical" href={canonicalHost + window.location.pathname} />
+				<link rel="canonical" href={canonicalHost + pathAndPage} />
 				{(() => {
 					if (status) {
 						return <meta name="prerender-status-code" content={status} />;

--- a/src/views/Intervention/Intervention.jsx
+++ b/src/views/Intervention/Intervention.jsx
@@ -186,6 +186,7 @@ const Intervention = ({ routeParamMap, routePath, data }) => {
 	};
 
 	const renderHelmet = () => {
+		const pathAndPage = window.location.pathname + `?pn=${pager.page}`;
 		const prerenderHeader = baseHost + window.location.pathname;
 		const status = location.state?.redirectStatus;
 
@@ -193,10 +194,10 @@ const Intervention = ({ routeParamMap, routePath, data }) => {
 			<Helmet>
 				<title>{`${replacedText.browserTitle} - ${siteName}`}</title>
 				<meta property="og:title" content={`${replacedText.pageTitle}`} />
-				<meta property="og:url" content={baseHost + window.location.pathname} />
+				<meta property="og:url" content={baseHost + pathAndPage} />
 				<meta name="description" content={replacedText.metaDescription} />
 				<meta property="og:description" content={replacedText.metaDescription} />
-				<link rel="canonical" href={canonicalHost + window.location.pathname} />
+				<link rel="canonical" href={canonicalHost + pathAndPage} />
 				{(() => {
 					if (status) {
 						return <meta name="prerender-status-code" content={status} />;

--- a/src/views/Manual/Manual.jsx
+++ b/src/views/Manual/Manual.jsx
@@ -71,14 +71,16 @@ const Manual = () => {
 	};
 
 	const renderHelmet = () => {
+		const pathAndPage = window.location.pathname + `?pn=${pager.page}`;
+
 		return (
 			<Helmet>
 				<title>{`${pageTitle} - ${siteName}`}</title>
 				<meta property="og:title" content={`${pageTitle}`} />
-				<meta property="og:url" content={baseHost + window.location.pathname} />
+				<meta property="og:url" content={baseHost + pathAndPage} />
 				<meta name="description" content={metaDescription} />
 				<meta property="og:description" content={metaDescription} />
-				<link rel="canonical" href={canonicalHost + window.location.pathname} />
+				<link rel="canonical" href={canonicalHost + pathAndPage} />
 			</Helmet>
 		);
 	};


### PR DESCRIPTION
- Update helmet rendering to includ page number in canonical url and og:url tags.
- Update existing tests for canonical and og:url tags to verify page number.
- Add tests for urls being updated when paging.

Closes #222