### PR TITLE
(#268) Redirected No Trials Page title not aligned to Filter Trials

### DIFF
--- a/src/components/molecules/no-results/no-results.jsx
+++ b/src/components/molecules/no-results/no-results.jsx
@@ -10,7 +10,7 @@ const NoResults = ({ replacedNoTrialsHtml }) => {
 
 	return (
 		<>
-			<div dangerouslySetInnerHTML={{ __html: noTrialsHtmlToDisplay }}></div>
+			<div className="no-results" dangerouslySetInnerHTML={{ __html: noTrialsHtmlToDisplay }}></div>
 		</>
 	);
 };

--- a/src/views/Disease/Disease.scss
+++ b/src/views/Disease/Disease.scss
@@ -84,6 +84,12 @@
 
 	&__content {
 		grid-area: content;
+
+		&:has( .no-results) {
+			@include at-media('desktop') {
+				grid-area: heading;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
* Made the no results page use grid-area heading for desktop or larger

Closes #268