### PR TITLE
(#355) Filter Trials section title gets focus at widescreen & desktop

### DIFF
--- a/src/features/filters/components/Sidebar/Sidebar.jsx
+++ b/src/features/filters/components/Sidebar/Sidebar.jsx
@@ -409,6 +409,7 @@ const Sidebar = ({ pageType = 'Disease', isDisabled = false, onFilterApplied = (
 				const isClosed = filterBtn.classList.contains('is-closed');
 				content.hidden = isClosed;
 				filterBtn.setAttribute('aria-expanded', !isClosed);
+				filterBtn.setAttribute('tabIndex', '0');
 			} else {
 				// If desktop view
 				// Ensure accordion is open and listener is removed
@@ -417,6 +418,7 @@ const Sidebar = ({ pageType = 'Disease', isDisabled = false, onFilterApplied = (
 				filterBtn.style.backgroundImage = minusSign; // Default to open style
 				content.removeAttribute('hidden');
 				filterBtn.setAttribute('aria-expanded', 'true');
+				filterBtn.setAttribute('tabIndex', '-1');
 			}
 		}
 


### PR DESCRIPTION
*Set tabIndex to -1 for widescreen and desktop and 0 for anything smaller

Closes #355