### PR TITLE
(#225) "carbon-c-14-ac0010" intervention treated as a c-code.

### DIFF
--- a/src/utils/__tests__/matchQueryParam.test.js
+++ b/src/utils/__tests__/matchQueryParam.test.js
@@ -37,4 +37,13 @@ describe('matchQueryParam', () => {
 
 		expect(matchQueryParam('C4872,breast-cancer')).toStrictEqual(matchedParam);
 	});
+
+	it('matches intervention names containing c-digits patterns as purl type', () => {
+		const matchedParam = {
+			paramType: queryParamType.purl,
+			queryParam: 'carbon-c-14-ac0010',
+		};
+
+		expect(matchQueryParam('carbon-c-14-ac0010')).toStrictEqual(matchedParam);
+	});
 });

--- a/src/utils/matchQueryParam.js
+++ b/src/utils/matchQueryParam.js
@@ -6,7 +6,7 @@ import { queryParamType } from '../constants';
  * @param {string} codeOrPurl the code or pretty URL name to match to regex
  */
 export const matchQueryParam = (codeOrPurl) => {
-	const regex = /(C[0-9]+)(,C[0-9]+)*$/i;
+	const regex = /^(C[0-9]+)(,C[0-9]+)*$/i;
 	if (regex.test(codeOrPurl)) {
 		return {
 			paramType: queryParamType.code,


### PR DESCRIPTION
Updates the regex to start from the beginnning.

Closes #225