### PR TITLE
(#351) Keep Scroll Position on Mobile after Filter Applied

### DIFF
--- a/src/components/atomic/scroll-restoration/__tests__/useScrollRestoration.tests.jsx
+++ b/src/components/atomic/scroll-restoration/__tests__/useScrollRestoration.tests.jsx
@@ -131,4 +131,81 @@ describe('useScrollRestoration()', () => {
 
 		expect(window.removeEventListener).toHaveBeenCalledWith('beforeunload', expect.any(Function));
 	});
+
+	it('should scroll to filter area on mobile when there is an error', () => {
+		// Set viewport to mobile width
+		Object.defineProperty(window, 'innerWidth', {
+			value: BREAKPOINTS.MOBILE_LG,
+			writable: true,
+		});
+
+		// Mock the sidebar element
+		const mockSidebar = document.createElement('div');
+		mockSidebar.className = 'ctla-sidebar';
+		document.body.appendChild(mockSidebar);
+
+		// Mock getBoundingClientRect
+		mockSidebar.getBoundingClientRect = jest.fn(() => ({
+			top: 200,
+			left: 0,
+			right: 0,
+			bottom: 0,
+			width: 0,
+			height: 0,
+		}));
+
+		// Mock pageYOffset
+		Object.defineProperty(window, 'pageYOffset', {
+			value: 100,
+			writable: true,
+		});
+
+		const ScrollMockComponent = () => {
+			useScrollRestoration();
+			return <div>Test Component</div>;
+		};
+
+		// Render with filter update AND scrollToError state
+		render(
+			<MemoryRouter initialEntries={[{ pathname: '/test', state: { filterUpdate: true, scrollToError: true } }]}>
+				<ScrollMockComponent />
+			</MemoryRouter>
+		);
+
+		// On mobile with error, should scroll to filter area (sidebar position - 20px offset)
+		// scrollTop = pageYOffset (100) + sidebarRect.top (200) - 20 = 280
+		expect(window.scrollTo).toHaveBeenCalledWith({
+			top: 280,
+			behavior: 'smooth',
+		});
+
+		// Clean up
+		document.body.removeChild(mockSidebar);
+	});
+
+	it('should scroll to top on mobile with error if sidebar not found', () => {
+		// Set viewport to mobile width
+		Object.defineProperty(window, 'innerWidth', {
+			value: BREAKPOINTS.MOBILE_LG,
+			writable: true,
+		});
+
+		const ScrollMockComponent = () => {
+			useScrollRestoration();
+			return <div>Test Component</div>;
+		};
+
+		// Render with filter update AND scrollToError state but no sidebar in DOM
+		render(
+			<MemoryRouter initialEntries={[{ pathname: '/test', state: { filterUpdate: true, scrollToError: true } }]}>
+				<ScrollMockComponent />
+			</MemoryRouter>
+		);
+
+		// Fallback to scroll to top when sidebar not found
+		expect(window.scrollTo).toHaveBeenCalledWith({
+			top: 0,
+			behavior: 'smooth',
+		});
+	});
 });

--- a/src/components/atomic/scroll-restoration/useScrollRestoration.js
+++ b/src/components/atomic/scroll-restoration/useScrollRestoration.js
@@ -9,12 +9,14 @@ export const useScrollRestoration = () => {
 
 	useEffect(() => {
 		const isFilterUpdate = location.state?.filterUpdate;
+		const scrollToError = location.state?.scrollToError;
 		const isMobileOrTablet = window.innerWidth < BREAKPOINTS.DESKTOP;
 
 		// Skip scroll-to-top for filter updates on mobile/tablet only
 		// On desktop (1024px+), filters are in a sidebar so scrolling to top is appropriate
 		// On mobile/tablet (<1024px), filters are inline so scrolling disrupts the user experience
-		if (isFilterUpdate && isMobileOrTablet) {
+		// Exception: When there's an error, scroll to show the error message in the filter area
+		if (isFilterUpdate && isMobileOrTablet && !scrollToError) {
 			prevLocationKey.current = location.key;
 			return;
 		}
@@ -33,6 +35,19 @@ export const useScrollRestoration = () => {
 		if (savedPosition && !isFilterUpdate) {
 			// Restore saved position for back/forward navigation
 			window.scrollTo(savedPosition.x, savedPosition.y);
+		} else if (scrollToError && isMobileOrTablet) {
+			// When there's an error on mobile/tablet, scroll to the filter/error area
+			// so the error message is visible to the user
+			const sidebar = document.querySelector('.ctla-sidebar');
+			if (sidebar) {
+				// Get the sidebar's position and scroll to it with some offset
+				const sidebarRect = sidebar.getBoundingClientRect();
+				const scrollTop = window.pageYOffset + sidebarRect.top - 20; // 20px offset from top
+				window.scrollTo({ top: scrollTop, behavior: 'smooth' });
+			} else {
+				// Fallback to top if sidebar not found
+				window.scrollTo({ top: 0, behavior: 'smooth' });
+			}
 		} else {
 			// Scroll to top for new navigations, filter updates on desktop, or initial load
 			window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -53,5 +68,5 @@ export const useScrollRestoration = () => {
 		return () => {
 			window.removeEventListener('beforeunload', handleBeforeUnload);
 		};
-	}, [location.key, location.state?.filterUpdate]);
+	}, [location.key, location.state?.filterUpdate, location.state?.scrollToError]);
 };

--- a/src/features/filters/components/Sidebar/Sidebar.jsx
+++ b/src/features/filters/components/Sidebar/Sidebar.jsx
@@ -26,6 +26,7 @@ import { isValidZipFormat } from '../../utils/locationUtils';
 import PropTypes from 'prop-types';
 import AppliedFilters from '../AppliedFilters/AppliedFilters';
 import { getFieldCode } from '../../utils/eddlAnalytics';
+import { BREAKPOINTS } from '../../../../constants/breakpoints';
 
 /**
  * Helper function to detect which field was added by comparing old and new filters
@@ -506,13 +507,41 @@ const Sidebar = ({ pageType = 'Disease', isDisabled = false, onFilterApplied = (
 	}, []); // No dependencies needed since function doesn't depend on props/state
 
 	/**
+	 * Effect to handle invalid query state:
+	 * 1. Blur any focused input to prevent focus remaining on cleared fields
+	 * 2. Scroll to the filter/error area on mobile so the error message is visible
+	 */
+	useEffect(() => {
+		if (isInvalidQuery) {
+			// Blur any focused element to prevent focus remaining on cleared fields
+			if (document.activeElement && document.activeElement !== document.body) {
+				document.activeElement.blur();
+			}
+
+			// On mobile/tablet, scroll to show the error message
+			if (window.innerWidth < BREAKPOINTS.DESKTOP) {
+				// Small delay to ensure the error message is rendered
+				const scrollTimer = setTimeout(() => {
+					const sidebar = document.querySelector('.ctla-sidebar');
+					if (sidebar) {
+						const sidebarRect = sidebar.getBoundingClientRect();
+						const scrollTop = window.pageYOffset + sidebarRect.top - 20; // 20px offset from top
+						window.scrollTo({ top: scrollTop, behavior: 'smooth' });
+					}
+				}, 100);
+				return () => clearTimeout(scrollTimer);
+			}
+		}
+	}, [isInvalidQuery]);
+
+	/**
 	 * Checks if any filters (age or location) are currently active.
 	 * Used to enable/disable the "Clear Filters" button.
 	 * @returns {boolean} True if at least one filter is active, false otherwise.
 	 */
 	const hasActiveFilters = () => {
 		// Check age filter (handles single value or potentially array in future)
-		const hasAgeFilter = filters.age != null && filters.age !== '';
+		const hasAgeFilter = filters.age != null && filters.age !== '' && filters.age.length !== 0;
 
 		// Check location filter (zip code must exist)
 		const hasLocationFilter = Boolean(filters.location?.zipCode);

--- a/src/features/filters/context/FilterContext/FilterContext.jsx
+++ b/src/features/filters/context/FilterContext/FilterContext.jsx
@@ -1082,7 +1082,11 @@ export function FilterProvider({ children, baseFilters = {}, pageType = 'Disease
 						replace: shouldReplace,
 						// Signal to ScrollRestoration that this is a filter update
 						// so it doesn't scroll to top when users interact with filters
-						state: { filterUpdate: true },
+						// Also signal if there's an error so it can scroll to show the error message
+						state: {
+							filterUpdate: true,
+							scrollToError: state.isInvalidQuery,
+						},
 					}
 				);
 			} else {


### PR DESCRIPTION
* Keep page position instead of jumping to top when dynamically refreshing results on mobile

Closes #351