### PR TITLE
(#421) Chat Now button not opening chat window

### DIFF
--- a/src/components/atomic/CISBanner/CISBanner.jsx
+++ b/src/components/atomic/CISBanner/CISBanner.jsx
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types';
 import { useStateValue } from '../../../store/store';
 import './CISBanner.scss';
 
-const CISBanner = ({ onLiveHelpClick }) => {
+const defaultLiveHelpClick = (url) => {
+	window.open(url, 'ProactiveLiveHelpForCTS', 'height=600,width=633');
+};
+
+const CISBanner = ({ onLiveHelpClick = defaultLiveHelpClick }) => {
 	const [{ cisBannerImgUrlLarge, cisBannerImgUrlSmall, liveHelpUrl }] = useStateValue();
 
 	const liveHelpClickHandler = (url) => {


### PR DESCRIPTION
- CISBanner rendered without onLiveHelpClick prop in NoResultsWithFilters caused the Chat Now button to silently fail
- Added a default handler that opens the LiveHelp chat popup window

Closes #421